### PR TITLE
POC: Fix team links in portal

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Services/TenantArtifacts/DockerClientTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/TenantArtifacts/DockerClientTests.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Defra.Cdp.Backend.Api.Config;
 using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.Github;
 using Defra.Cdp.Backend.Api.Services.TenantArtifacts;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -17,11 +18,12 @@ public class DockerClientTests
 
     private readonly HttpClient _httpMock = Substitute.For<HttpClient>();
     private readonly ILayerService _layerServiceMock = Substitute.For<ILayerService>();
+    private readonly IRepositoryService _repositoryServiceMock = Substitute.For<IRepositoryService>();
 
     public DockerClientTests()
     {
         _artifactScanner = new ArtifactScanner(_deployableServiceMock, _layerServiceMock, _dockerClientMock,
-            ConsoleLogger.CreateLogger<ArtifactScanner>());
+            ConsoleLogger.CreateLogger<ArtifactScanner>(), _repositoryServiceMock, _httpMock);
     }
 
     [Fact]

--- a/Defra.Cdp.Backend.Api/Models/DeployableArtifact.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeployableArtifact.cs
@@ -5,6 +5,13 @@ using MongoDB.Bson.Serialization.IdGenerators;
 
 namespace Defra.Cdp.Backend.Api.Models;
 
+public sealed class TeamUserService
+{
+    [BsonIgnoreIfDefault]
+    public string TeamId { get; init; } = default!;
+    public string TeamName { get; init; } = default!;
+}
+
 public sealed class DeployableArtifact
 {
     [BsonId(IdGenerator = typeof(ObjectIdGenerator))]
@@ -24,6 +31,8 @@ public sealed class DeployableArtifact
 
     public string? ServiceName { get; init; } = default!;
 
+    public TeamUserService? Team { get; init; } = default!;
+
     public int ScannerVersion { get; init; } = default!;
 
     // TODO: replace this with references to the layers, maybe something like: {filename: layer}?  
@@ -35,4 +44,4 @@ public sealed class DeployableArtifact
 
 public sealed record DeployableArtifactFile(string FileName, string Path, string LayerSha256);
 
-public sealed record ServiceInfo(string ServiceName, string? GithubUrl, string ImageName);
+public sealed record ServiceInfo(string ServiceName, string? GithubUrl, string ImageName, string? TeamName, string? TeamId);


### PR DESCRIPTION
:rotating_light: Note this is POC code only :rotating_light: 

This work adds `teamName` and `teamId` to the `DeployableArtifact`:
- in the `ArtifactScanner` uses the `serviceName` available on an image to get the GitHub data from the `repository` collection in the Portal Backend
- then uses the team `GitHub` handle to query a new endpoint in the user service
- The CDP `teamName` and `teamId` are then added to the `DeployableArtifact`
- The same functionality can be used for the CreatePlaceholder work
- Updates to portal frontend to use this new teamName and teamId from `portalBackendApiUrl/services/{serviceName}`

## Associated PR's

- https://github.com/DEFRA/cdp-user-service-backend/pull/44
- https://github.com/DEFRA/cdp-portal-frontend/pull/212