### PR TITLE
Provide created dates for versions

### DIFF
--- a/Defra.Cdp.Backend.Api/Models/DeployableArtifact.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeployableArtifact.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-using Defra.Cdp.Backend.Api.Services.TenantArtifacts;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.IdGenerators;
@@ -41,5 +40,10 @@ public sealed class DeployableArtifact
 
 public sealed record DeployableArtifactFile(string FileName, string Path, string LayerSha256);
 
-public sealed record ServiceInfo(string ServiceName, string? GithubUrl, string ImageName,
+public sealed record ServiceInfo(
+    string ServiceName,
+    string? GithubUrl,
+    string ImageName,
     IEnumerable<RepositoryTeam> Teams);
+
+public sealed record TagInfo(string Tag, DateTime Created);


### PR DESCRIPTION
via the `/deployables/<imageName>` endpoint

## Example
The endpoint `/deployables/cdp-portal-frontend` now returns

```
[
    {
        "tag": "0.319.0",
        "created": "2024-03-08T17:58:10.426Z"
    },
    {
        "tag": "0.318.0",
        "created": "2024-03-08T16:44:21.848Z"
    }
]
```

