### PR TITLE
Filter /repositories to just return cdp repositories

### DIFF
--- a/Defra.Cdp.Backend.Api/Services/Github/RepositoryService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Github/RepositoryService.cs
@@ -65,13 +65,18 @@ public class RepositoryService : MongoService<Repository>, IRepositoryService
 
     public async Task<List<Repository>> AllRepositories(bool excludeTemplates, CancellationToken cancellationToken)
     {
+        var builder = Builders<Repository>.Filter;
+        var filter = builder.Empty;
+        var withoutTemplatesFilter = builder.Eq(r => r.IsTemplate, false);
+        var withCdpTopicFilter = builder.Where(r => r.Topics.Contains("cdp"));
+
         var findDefinition = excludeTemplates
-            ? Builders<Repository>.Filter.Eq(r => r.IsTemplate, false)
-            : Builders<Repository>.Filter.Empty;
+            ? withoutTemplatesFilter
+            : filter;
 
         var repositories =
             await Collection
-                .Find(findDefinition)
+                .Find(findDefinition & withCdpTopicFilter)
                 .SortBy(r => r.Id)
                 .ToListAsync(cancellationToken);
         return repositories;


### PR DESCRIPTION
Currently `/repositories` is returning a JSON payload with `14k` lines, which is all DEFRA GitHub repos. 

This PR filters them down to just return our repos, GitHub repos with the topic `cdp`, which is now a little over 1000 lines of JSON.