### PR TITLE
Consume dates from get_all_secret_keys

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Services/Secrets/SecretEventHandlerTest.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Secrets/SecretEventHandlerTest.cs
@@ -30,7 +30,8 @@ public class SecretEventHandlerTest
     [Fact]
     public void TryParseMessageHeaderWithValidPayload()
     {
-       var body = "{\"source\": \"cdp-secret-manager-lambda\", \"statusCode\": 200, \"action\": \"get_all_secret_keys\", \"body\": {}}";
+        var body =
+            @"{""source"": ""cdp-secret-manager-lambda"", ""statusCode"": 200, ""action"": ""get_all_secret_keys"", ""body"": {}}";
        var res = SecretEventHandler.TryParseMessageHeader(body);
        Assert.NotNull(res);
     }
@@ -38,7 +39,8 @@ public class SecretEventHandlerTest
     [Fact]
     public void TryParseMessageHeaderInvalid()
     {
-        var otherLambda = "{\"source\": \"cdp-some-other-lambda\", \"statusCode\": 200, \"action\": \"get_all_secret_keys\", \"body\": {}}";
+        var otherLambda =
+            @"{""source"": ""cdp-some-other-lambda"", ""statusCode"": 200, ""action"": ""get_all_secret_keys"", ""body"": {}}";
         var res = SecretEventHandler.TryParseMessageHeader(otherLambda);
         Assert.Null(res);
         
@@ -54,18 +56,50 @@ public class SecretEventHandlerTest
     [Fact]
     public void CanExtractBody()
     {
-        var body = "{\"source\": \"cdp-secret-manager-lambda\", \"statusCode\": 200, \"action\": \"get_all_secret_keys\", \"body\": " +
-                   "{ \"get_all_secret_keys\": true, " +
-                   "\"exception\": \"\", " +
-                   "\"environment\": \"dev\", " +
-                   "\"keys\": {\"cdp/service/foo\": [\"FOO\"]}" +
-                   "}}";
+        var body =
+            @"{""source"": ""cdp-secret-manager-lambda"", ""statusCode"": 200, ""action"": ""get_all_secret_keys"",
+                ""body"":
+                   {
+                       ""get_all_secret_keys"": true,
+                        ""exception"": """",
+                        ""environment"": ""dev"",
+                        ""secretKeys"": {
+                            ""cdp/services/service-1"": {
+                                ""createdDate"": ""2024-01-01T00:00:00"",
+                                ""keys"": [""key1"", ""key2""],
+                                ""lastChangedDate"": ""2022-01-01T00:00:00""
+                            },
+                            ""cdp/services/service-2"": {
+                                ""createdDate"": ""2024-02-01T00:00:00"",
+                                ""keys"": [""key3"", ""key4""],
+                                ""lastChangedDate"": ""2023-01-01T00:00:00""
+                            },
+                            ""cdp/services/service-3"": {
+                                ""createdDate"": ""2021-01-01T00:00:00"",
+                                ""keys"": [""key5"", ""key6""],
+                                ""lastChangedDate"": ""2023-02-01T00:00:00""
+                            }
+                        }
+                    }
+            }";
         var res = SecretEventHandler.TryParseMessageHeader(body);
         Assert.NotNull(res);
 
         var parsedBody = res.Body.Deserialize<BodyGetAllSecretKeys>();
         Assert.Equal("dev", parsedBody?.Environment);
         Assert.Equal("", parsedBody?.Exception);
-        Assert.Equal(1, parsedBody?.Keys.Count);
+        Assert.Equal(3, parsedBody?.SecretKeys.Count);
+
+        Assert.Equal("2024-01-01T00:00:00", parsedBody?.SecretKeys["cdp/services/service-1"].CreatedDate);
+        Assert.Equal("2022-01-01T00:00:00", parsedBody?.SecretKeys["cdp/services/service-1"].LastChangedDate);
+        Assert.Equal(new [] { "key1", "key2" }, parsedBody?.SecretKeys["cdp/services/service-1"].Keys);
+
+        Assert.Equal("2024-02-01T00:00:00", parsedBody?.SecretKeys["cdp/services/service-2"].CreatedDate);
+        Assert.Equal("2023-01-01T00:00:00", parsedBody?.SecretKeys["cdp/services/service-2"].LastChangedDate);
+        Assert.Equal(new [] { "key3", "key4" }, parsedBody?.SecretKeys["cdp/services/service-2"].Keys);
+
+        Assert.Equal("2021-01-01T00:00:00", parsedBody?.SecretKeys["cdp/services/service-3"].CreatedDate);
+        Assert.Equal("2023-02-01T00:00:00", parsedBody?.SecretKeys["cdp/services/service-3"].LastChangedDate);
+        Assert.Equal(new [] { "key5", "key6" }, parsedBody?.SecretKeys["cdp/services/service-3"].Keys);
     }
 }

--- a/Defra.Cdp.Backend.Api/Endpoints/DeploymentsEndpointV2.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/DeploymentsEndpointV2.cs
@@ -77,9 +77,10 @@ public static class DeploymentsEndpointV2
     {
         var deployment = await deploymentsService.FindDeployment(deploymentId, cancellationToken);
 
-        return deployment == null
-            ? Results.NotFound(new ApiError($"{deploymentId} was not found"))
-            : Results.Ok(deployment);
+        if (deployment == null) return Results.NotFound(new ApiError($"{deploymentId} was not found"));
+
+        deployment.Secrets.Keys.Sort();
+        return Results.Ok(deployment);
     }
 
     private static async Task<IResult> WhatsRunningWhere(IDeploymentsServiceV2 deploymentsService,

--- a/Defra.Cdp.Backend.Api/Endpoints/TenantSecretsEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/TenantSecretsEndpoint.cs
@@ -16,6 +16,9 @@ public static class TenantSecretsEndpoint
         string service, CancellationToken cancellationToken)
     {
         var secrets = await secretsService.FindSecrets(environment, service, cancellationToken);
-        return secrets == null ? Results.NotFound(new ApiError("secrets not found")) : Results.Ok(secrets);
+        if (secrets == null) return Results.NotFound(new ApiError("secrets not found"));
+
+        secrets.Keys.Sort();
+        return Results.Ok(secrets);
     }
 }

--- a/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
@@ -32,7 +32,7 @@ public class DeploymentV2
     public bool Unstable { get; set; } = false;
 
     public string? ConfigVersion { get; init; } = default!;
-    public List<string> Secrets { get; init; } = new();
+    public SecretKey Secrets { get; init; } = new();
     
     // From ECS Service Deployment State Change messages 
     public string? LastDeploymentStatus { get; set; }

--- a/Defra.Cdp.Backend.Api/Models/RequestedDeployment.cs
+++ b/Defra.Cdp.Backend.Api/Models/RequestedDeployment.cs
@@ -36,6 +36,6 @@ public sealed class RequestedDeployment
     public string? ConfigVersion { get; init; } = default!;
     
     [property: JsonPropertyName("secrets")]
-    public List<string> Secrets { get; init; } = new();
+    public SecretKey Secrets { get; init; } = new();
 
 }

--- a/Defra.Cdp.Backend.Api/Models/SecretKey.cs
+++ b/Defra.Cdp.Backend.Api/Models/SecretKey.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.Cdp.Backend.Api.Models;
+
+public record SecretKey
+{
+    [JsonPropertyName("keys")] public List<string> Keys { get; init; } = new();
+    [JsonPropertyName("lastChangedDate")] public string LastChangedDate { get; init; } = "";
+    [JsonPropertyName("createdDate")] public string CreatedDate { get; init; } = "";
+}

--- a/Defra.Cdp.Backend.Api/Models/TenantSecrets.cs
+++ b/Defra.Cdp.Backend.Api/Models/TenantSecrets.cs
@@ -20,4 +20,10 @@ public class TenantSecrets
     
     [property: JsonPropertyName("secrets")]
     public List<string> Secrets { get; init; } = new();
+
+    [property: JsonPropertyName("lastChangedDate")]
+    public string LastChangedDate { get; init; } = default!;
+
+    [property: JsonPropertyName("createdDate")]
+    public string CreatedDate { get; init; } = default!;
 }

--- a/Defra.Cdp.Backend.Api/Models/TenantSecrets.cs
+++ b/Defra.Cdp.Backend.Api/Models/TenantSecrets.cs
@@ -17,9 +17,8 @@ public class TenantSecrets
     
     [property: JsonPropertyName("environment")]
     public string Environment { get; init; } = default!;
-    
-    [property: JsonPropertyName("secrets")]
-    public List<string> Secrets { get; init; } = new();
+
+    [property: JsonPropertyName("keys")] public List<string> Keys { get; init; } = new();
 
     [property: JsonPropertyName("lastChangedDate")]
     public string LastChangedDate { get; init; } = default!;

--- a/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
@@ -68,7 +68,7 @@ public class SecretEventHandler : ISecretEventHandler
             {
                 Service = service,
                 Environment = body.Environment,
-                Secrets = value.Keys,
+                Keys = value.Keys,
                 LastChangedDate = value.LastChangedDate,
                 CreatedDate = value.CreatedDate
             });

--- a/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
@@ -43,7 +43,7 @@ public class SecretEventHandler : ISecretEventHandler
      * secret values set along with a list of the key/environment variable the secret is bound to,
      * but NOT the actual secret itself.
      */
-    public async Task HandleGetAllSecrets(MessageHeader header, CancellationToken cancellationToken)
+    private async Task HandleGetAllSecrets(MessageHeader header, CancellationToken cancellationToken)
     {
         var body = header.Body?.Deserialize<BodyGetAllSecretKeys>();
         if (body == null)
@@ -60,13 +60,17 @@ public class SecretEventHandler : ISecretEventHandler
         
         _logger.LogInformation("Updating secrets in {Environment}", body.Environment);
         var secrets = new List<TenantSecrets>();
-        
-        foreach (var kv in body.Keys)
+
+        foreach (var (key, value) in body.SecretKeys)
         {
-            var service = kv.Key.Replace("cdp/services/", "");
+            var service = key.Replace("cdp/services/", "");
             secrets.Add(new TenantSecrets
             {
-                Service = service, Environment = body.Environment, Secrets = kv.Value
+                Service = service,
+                Environment = body.Environment,
+                Secrets = value.Keys,
+                LastChangedDate = value.LastChangedDate,
+                CreatedDate = value.CreatedDate
             });
         }
         

--- a/Defra.Cdp.Backend.Api/Services/Secrets/SecretsService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/SecretsService.cs
@@ -31,7 +31,8 @@ public class SecretsService : MongoService<TenantSecrets>, ISecretsService
 
     public async Task<TenantSecrets?> FindSecrets(string environment, string service, CancellationToken cancellationToken)
     {
-        return await Collection.Find(t => t.Service == service && t.Environment == environment).FirstOrDefaultAsync(cancellationToken);
+        return await Collection.Find(t => t.Service == service && t.Environment == environment)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     public async Task UpdateSecrets(TenantSecrets secret, CancellationToken cancellationToken)

--- a/Defra.Cdp.Backend.Api/Services/Secrets/events/Message.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/events/Message.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Defra.Cdp.Backend.Api.Models;
 
 namespace Defra.Cdp.Backend.Api.Services.Secrets.events;
 
@@ -18,13 +19,6 @@ public record MessageHeader
     [JsonPropertyName("source")] public string? Source { get; init; }
     [JsonPropertyName("action")] public string? Action { get; init; }
     [JsonPropertyName("body")] public JsonObject? Body { get; init; }
-}
-
-public record SecretKey
-{
-    [JsonPropertyName("keys")] public List<string> Keys { get; init; } = new();
-    [JsonPropertyName("lastChangedDate")] public string LastChangedDate { get; init; } = "";
-    [JsonPropertyName("createdDate")] public string CreatedDate { get; init; } = "";
 }
 
 public record BodyGetAllSecretKeys

--- a/Defra.Cdp.Backend.Api/Services/Secrets/events/Message.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/events/Message.cs
@@ -20,9 +20,16 @@ public record MessageHeader
     [JsonPropertyName("body")] public JsonObject? Body { get; init; }
 }
 
+public record SecretKey
+{
+    [JsonPropertyName("keys")] public List<string> Keys { get; init; } = new();
+    [JsonPropertyName("lastChangedDate")] public string LastChangedDate { get; init; } = "";
+    [JsonPropertyName("createdDate")] public string CreatedDate { get; init; } = "";
+}
+
 public record BodyGetAllSecretKeys
 {
-    [JsonPropertyName("keys")] public Dictionary<string, List<string>> Keys { get; init; } = new();
+    [JsonPropertyName("secretKeys")] public Dictionary<string, SecretKey> SecretKeys { get; init; } = new();
     [JsonPropertyName("exception")] public string Exception { get; init; } = "";
     [JsonPropertyName("environment")] public string Environment { get; init; } = "";
 }


### PR DESCRIPTION
Support new format of secrets that now contains:
- `lastChangedDate`
- `createdDate`

## Associated PR's:
- https://github.com/DEFRA/cdp-secret-manager-lambda/pull/25
- https://github.com/DEFRA/cdp-self-service-ops/pull/242
- https://github.com/DEFRA/cdp-portal-frontend/pull/473


Needs discussion mainly about:
- [x] How to update previous data
- [x] How to roll out
- [ ] What else may be effected that I am unaware of?