### PR TITLE
204100 add secret

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Services/Secrets/SecretEventHandlerTest.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Secrets/SecretEventHandlerTest.cs
@@ -13,7 +13,9 @@ public class SecretEventHandlerTest
     public async void WillProcessGetAllSecretsPayload()
     {
         var service =  Substitute.For<ISecretsService>();
-        var eventHandler = new SecretEventHandler(service, ConsoleLogger.CreateLogger<SecretEventHandler>());
+        var pendingSecretsService =  Substitute.For<IPendingSecretsService>();
+        var eventHandler = new SecretEventHandler(service, pendingSecretsService,
+            ConsoleLogger.CreateLogger<SecretEventHandler>());
         
         var mockPayload = SecretEventHandler.TryParseMessageHeader(await File.ReadAllTextAsync("Resources/payload-get-all-secrets.json"));
 

--- a/Defra.Cdp.Backend.Api/Endpoints/DeploymentsEndpointV2.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/DeploymentsEndpointV2.cs
@@ -119,7 +119,7 @@ public static class DeploymentsEndpointV2
         var secrets = await secretsService.FindSecrets(deployment.Environment, deployment.Service, cancellationToken);
         if (secrets != null)
         {
-            deployment.Secrets = secrets.AsDeploymentSecrets();
+            deployment.Secrets = secrets.AsTenantSecretKeys();
         }
         
         await deploymentsServiceV2.RegisterDeployment(deployment, cancellationToken);

--- a/Defra.Cdp.Backend.Api/Endpoints/TenantSecretsEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/TenantSecretsEndpoint.cs
@@ -9,16 +9,77 @@ public static class TenantSecretsEndpoint
     public static IEndpointRouteBuilder MapTenantSecretsEndpoint(this IEndpointRouteBuilder app)
     {
         app.MapGet("secrets/{environment}/{service}", FindTenantSecrets);
+        app.MapGet("secrets/{service}", FindAllTenantSecrets);
+        app.MapPost("secrets/register/pending", RegisterPendingSecret);
         return app;
     }
 
-    static async Task<IResult> FindTenantSecrets([FromServices] ISecretsService secretsService, string environment,
-        string service, CancellationToken cancellationToken)
+    private static async Task<IResult> FindTenantSecrets(
+        [FromServices] ISecretsService secretsService,
+        [FromServices] IPendingSecretsService pendingSecretsService,
+        string environment, string service, CancellationToken cancellationToken)
     {
         var secrets = await secretsService.FindSecrets(environment, service, cancellationToken);
-        if (secrets == null) return Results.NotFound(new ApiError("secrets not found"));
+        if (secrets == null) return Results.NotFound(new ApiError("No secrets found"));
 
+        var pendingSecrets = await pendingSecretsService.FindPendingSecrets(environment, service, cancellationToken);
+        var pendingSecretKeys = pendingSecrets?.Pending.Select(p => p.SecretKey).Distinct().ToList() ?? new List<string>();
+
+        var exceptionMessage =
+            await pendingSecretsService.PullExceptionMessage(environment, service, cancellationToken);
+
+        pendingSecretKeys?.Sort();
         secrets.Keys.Sort();
-        return Results.Ok(secrets);
+
+        return Results.Ok( new TenantSecretsResponse(
+            secrets.Service,
+            secrets.Environment,
+            secrets.Keys,
+            secrets.LastChangedDate,
+            secrets.CreatedDate,
+            pendingSecretKeys,
+            exceptionMessage)
+        );
+    }
+
+    private static async Task<IResult> FindAllTenantSecrets(
+        [FromServices] ISecretsService secretsService, string service, CancellationToken cancellationToken)
+    {
+        var allSecrets = await secretsService.FindAllSecrets(service, cancellationToken);
+        return !allSecrets.Any() ?  Results.NotFound(new ApiError("No secrets found")) : Results.Ok(allSecrets);
+    }
+
+    private static async Task<IResult> RegisterPendingSecret(
+        [FromServices] IPendingSecretsService pendingSecretsService,
+        RegisterPendingSecret registerPendingSecret,
+        CancellationToken cancellationToken)
+    {
+        await pendingSecretsService.RegisterPendingSecret(registerPendingSecret, cancellationToken);
+        return Results.Ok(registerPendingSecret);
+    }
+
+    private sealed record TenantSecretsResponse(
+        string Message,
+        string Service,
+        string Environment,
+        List<string> Keys,
+        string LastChangedDate,
+        string CreatedDate,
+        List<string>? Pending,
+        string? ExceptionMessage)
+    {
+        public TenantSecretsResponse(
+            string service, string environment, List<string> keys, string lastChangedDate, string createdDate,
+            List<string>? pending, string? exceptionMessage) : this(
+            "success",
+            service,
+            environment,
+            keys,
+            lastChangedDate,
+            createdDate,
+            pending,
+            exceptionMessage)
+        {
+        }
     }
 }

--- a/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
@@ -32,7 +32,7 @@ public class DeploymentV2
     public bool Unstable { get; set; } = false;
 
     public string? ConfigVersion { get; init; } = default!;
-    public DeploymentSecrets Secrets { get; set; } = new();
+    public TenantSecretKeys Secrets { get; set; } = new();
     
     // From ECS Service Deployment State Change messages 
     public string? LastDeploymentStatus { get; set; }

--- a/Defra.Cdp.Backend.Api/Models/PendingSecret.cs
+++ b/Defra.Cdp.Backend.Api/Models/PendingSecret.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.IdGenerators;
+
+namespace Defra.Cdp.Backend.Api.Models;
+
+public class PendingSecrets
+{
+    [BsonId(IdGenerator = typeof(ObjectIdGenerator))]
+    [BsonIgnoreIfDefault]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    public ObjectId? Id { get; init; } = default;
+
+    [property: JsonPropertyName("environment")]
+    public string Environment { get; init; } = default!;
+
+    [property: JsonPropertyName("service")]
+    public string Service { get; init; } = default!;
+
+    [property: JsonPropertyName("pending")]
+    public List<PendingSecret> Pending { get; init; } = new();
+
+    [property: JsonPropertyName("exceptionMessage")]
+    public List<string> ExceptionMessages { get; init; } = new();
+
+    [BsonElement("createdAt")]
+    [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+}
+
+public class PendingSecret
+{
+    [property: JsonPropertyName("secretKey")]
+    public string SecretKey { get; init; } = default!;
+
+    [property: JsonPropertyName("action")] public string Action { get; init; } = default!;
+}
+
+public class RegisterPendingSecret
+{
+    [property: JsonPropertyName("service")]
+    public string Service { get; init; } = default!;
+
+    [property: JsonPropertyName("environment")]
+    public string Environment { get; init; } = default!;
+
+    [property: JsonPropertyName("secretKey")]
+    public string SecretKey { get; init; } = default!;
+
+    [property: JsonPropertyName("action")] public string Action { get; init; } = default!;
+}

--- a/Defra.Cdp.Backend.Api/Models/TenantSecretKeys.cs
+++ b/Defra.Cdp.Backend.Api/Models/TenantSecretKeys.cs
@@ -5,7 +5,7 @@ namespace Defra.Cdp.Backend.Api.Models;
 /**
  * A cut down version of TenantSecrets
  */
-public record DeploymentSecrets
+public record TenantSecretKeys
 {
     [JsonPropertyName("keys")] public List<string> Keys { get; init; } = new();
     [JsonPropertyName("lastChangedDate")] public string LastChangedDate { get; init; } = "";

--- a/Defra.Cdp.Backend.Api/Models/TenantSecrets.cs
+++ b/Defra.Cdp.Backend.Api/Models/TenantSecrets.cs
@@ -26,8 +26,8 @@ public class TenantSecrets
     [property: JsonPropertyName("createdDate")]
     public string CreatedDate { get; init; } = default!;
 
-    public DeploymentSecrets AsDeploymentSecrets()
+    public TenantSecretKeys AsTenantSecretKeys()
     {
-        return new DeploymentSecrets { Keys = Keys, CreatedDate = CreatedDate, LastChangedDate = LastChangedDate };
+        return new TenantSecretKeys { Keys = Keys, CreatedDate = CreatedDate, LastChangedDate = LastChangedDate };
     }
 }

--- a/Defra.Cdp.Backend.Api/Program.cs
+++ b/Defra.Cdp.Backend.Api/Program.cs
@@ -144,6 +144,9 @@ builder.Services.AddSingleton<ISecretsService, SecretsService>();
 builder.Services.AddSingleton<ISecretEventHandler, SecretEventHandler>();
 builder.Services.AddSingleton<SecretEventListener>();
 
+// Pending Secrets
+builder.Services.AddSingleton<IPendingSecretsService, PendingSecretsService>();
+
 builder.Services.AddSingleton<MongoLock>();
 
 // Validators

--- a/Defra.Cdp.Backend.Api/Services/Secrets/PendingSecretsService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/PendingSecretsService.cs
@@ -1,0 +1,157 @@
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Mongo;
+using MongoDB.Driver;
+
+namespace Defra.Cdp.Backend.Api.Services.Secrets;
+
+public interface IPendingSecretsService
+{
+    public Task RegisterPendingSecret(RegisterPendingSecret registerPendingSecret, CancellationToken cancellationToken);
+
+    public Task<PendingSecret?> ExtractPendingSecret(string environment, string service, string secretKey,
+        string action, CancellationToken cancellationToken);
+
+    public Task<PendingSecrets?> FindPendingSecrets(string environment, string service,
+        CancellationToken cancellationToken);
+
+    public Task AddException(string environment, string service, string secretKey,
+        string action, string exceptionMessage, CancellationToken cancellationToken);
+
+    public Task<string?> PullExceptionMessage(string environment, string service, CancellationToken cancellationToken);
+}
+
+public class PendingSecretsService : MongoService<PendingSecrets>, IPendingSecretsService
+{
+    private readonly ILogger<PendingSecretsService> _logger;
+
+    public PendingSecretsService(IMongoDbClientFactory connectionFactory, ILoggerFactory loggerFactory) : base(
+        connectionFactory, "pendingsecrets", loggerFactory)
+    {
+        _logger = loggerFactory.CreateLogger<PendingSecretsService>();
+    }
+
+    protected override List<CreateIndexModel<PendingSecrets>> DefineIndexes(
+        IndexKeysDefinitionBuilder<PendingSecrets> builder)
+    {
+        var serviceAndEnv = new CreateIndexModel<PendingSecrets>(builder.Combine(
+            builder.Ascending(p => p.Service),
+            builder.Ascending(p => p.Environment)
+        ));
+
+        var ttlIndex = new CreateIndexModel<PendingSecrets>(
+            builder.Ascending(p => p.CreatedAt),
+            new CreateIndexOptions
+            {
+                ExpireAfter = TimeSpan.FromMinutes(2)
+            }
+        );
+
+        return new List<CreateIndexModel<PendingSecrets>> { serviceAndEnv, ttlIndex };
+    }
+
+    public async Task RegisterPendingSecret(
+        RegisterPendingSecret registerPendingSecret,
+        CancellationToken cancellationToken
+    )
+    {
+        var fb = new FilterDefinitionBuilder<PendingSecrets>();
+
+        var filter = fb.And(
+            fb.Eq(p => p.Service, registerPendingSecret.Service),
+            fb.Eq(p => p.Environment, registerPendingSecret.Environment)
+        );
+
+        var update = Builders<PendingSecrets>
+            .Update
+            .Set(p => p.CreatedAt, DateTime.UtcNow)
+            .Push(p => p.Pending,
+                new PendingSecret
+                {
+                    SecretKey = registerPendingSecret.SecretKey, Action = registerPendingSecret.Action
+                });
+
+        await Collection.UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true }, cancellationToken);
+    }
+
+    public async Task<PendingSecret?> ExtractPendingSecret(string environment, string service, string secretKey,
+        string action, CancellationToken cancellationToken)
+    {
+        var fb = new FilterDefinitionBuilder<PendingSecrets>();
+
+        var filter = fb.And(
+            fb.Eq(p => p.Service, service),
+            fb.Eq(p => p.Environment, environment)
+        );
+
+        var update = Builders<PendingSecrets>
+            .Update
+            .PullFilter(p => p.Pending, s => s.Action == action && s.SecretKey == secretKey);
+
+        var result = await Collection.FindOneAndUpdateAsync(filter, update,
+            new FindOneAndUpdateOptions<PendingSecrets> { ReturnDocument = ReturnDocument.Before }, cancellationToken);
+
+        return result?.Pending.FirstOrDefault(p => p.Action == action && p.SecretKey == secretKey);
+    }
+
+    public async Task<PendingSecrets?> FindPendingSecrets(string environment, string service,
+        CancellationToken cancellationToken)
+    {
+        var fb = new FilterDefinitionBuilder<PendingSecrets>();
+
+        var filter = fb.And(
+            fb.Eq(p => p.Service, service),
+            fb.Eq(p => p.Environment, environment)
+        );
+
+
+        return await Collection.Find(filter).FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task AddException(
+        string environment, string service, string secretKey,
+        string action, string exceptionMessage, CancellationToken cancellationToken
+    )
+    {
+        var pendingSecret = await ExtractPendingSecret(environment, service, secretKey, action, cancellationToken);
+
+        if (pendingSecret != null)
+        {
+            var fb = new FilterDefinitionBuilder<PendingSecrets>();
+            var filter = fb.And(
+                fb.Eq(p => p.Service, service),
+                fb.Eq(p => p.Environment, environment)
+            );
+
+            var update = Builders<PendingSecrets>
+                .Update
+                .Set(p => p.CreatedAt, DateTime.UtcNow)
+                .Push(p => p.ExceptionMessages, exceptionMessage);
+
+            await Collection.UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true }, cancellationToken);
+        }
+        else
+        {
+            _logger.LogInformation("Add Exception: Secret {SecretKey} not found in pending secrets", secretKey);
+        }
+    }
+
+    public async Task<string?> PullExceptionMessage(string environment, string service,
+        CancellationToken cancellationToken)
+    {
+        var fb = new FilterDefinitionBuilder<PendingSecrets>();
+
+        var filter = fb.And(
+            fb.Eq(p => p.Service, service),
+            fb.Eq(p => p.Environment, environment)
+        );
+
+        var update = Builders<PendingSecrets>
+            .Update
+            .PopFirst(p => p.ExceptionMessages);
+
+        var result = await Collection.FindOneAndUpdateAsync(filter, update,
+            new FindOneAndUpdateOptions<PendingSecrets> { ReturnDocument = ReturnDocument.Before }, cancellationToken);
+
+        return result?.ExceptionMessages.FirstOrDefault();
+    }
+}

--- a/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
@@ -17,12 +17,15 @@ public class SecretEventHandler : ISecretEventHandler
 {
     
     private readonly ISecretsService _secretsService;
+    private readonly IPendingSecretsService _pendingSecretsService;
     private readonly ILogger<SecretEventHandler> _logger;
-    
-    public SecretEventHandler(ISecretsService secretsService, ILogger<SecretEventHandler> logger)
+
+    public SecretEventHandler(ISecretsService secretsService, IPendingSecretsService pendingSecretsService,
+        ILogger<SecretEventHandler> logger)
     {
         _logger = logger;
         _secretsService = secretsService;
+        _pendingSecretsService = pendingSecretsService;
     }
 
     public async Task Handle(MessageHeader header, CancellationToken cancellationToken)
@@ -31,6 +34,9 @@ public class SecretEventHandler : ISecretEventHandler
         {
             case "get_all_secret_keys":
                 await HandleGetAllSecrets(header, cancellationToken);
+                break;
+            case "add_secret":
+                await HandleAddSecret(header, cancellationToken);
                 break;
             default:
                 _logger.LogDebug("Ignoring action: {Action} not handled", header.Action);
@@ -56,9 +62,10 @@ public class SecretEventHandler : ISecretEventHandler
         {
             _logger.LogError("get_all_secret_keys message contained exception {}", body.Exception);
             return;
-        } 
-        
-        _logger.LogInformation("Updating secrets in {Environment}", body.Environment);
+        }
+
+        _logger.LogInformation("Get All Secrets: Processing {Action}", header.Action);
+        _logger.LogInformation("Get All Secrets: Updating secrets in {Environment}", body.Environment);
         var secrets = new List<TenantSecrets>();
 
         foreach (var (key, value) in body.SecretKeys)
@@ -73,9 +80,51 @@ public class SecretEventHandler : ISecretEventHandler
                 CreatedDate = value.CreatedDate
             });
         }
-        
+
         await _secretsService.UpdateSecrets(secrets, cancellationToken);
-        _logger.LogInformation("Updated secrets for {Environment}", body.Environment);
+        _logger.LogInformation("Get All Secrets: Updated secrets for {Environment}", body.Environment);
+    }
+
+    /**
+     * Handler for add_secret action. If the add_secret request matches a pending secret then move the pending secret
+     * to the tenant secrets collection.
+     */
+    private async Task HandleAddSecret(MessageHeader header, CancellationToken cancellationToken)
+    {
+        var body = header.Body?.Deserialize<BodyAddSecret>();
+        if (body == null)
+        {
+            _logger.LogInformation("Add Secret: Failed to parse body of 'add_secret' message");
+            return;
+        }
+
+        _logger.LogInformation("Add Secret: Processing {Action}", header.Action);
+        var service = body.SecretName.Replace("cdp/services/", "");
+
+        if (body.Exception != "")
+        {
+            await _pendingSecretsService.AddException(
+                body.Environment, service, body.SecretKey, "add_secret", body.Exception, cancellationToken);
+            _logger.LogError("Add Secret: add_secret message contained exception {Exception}", body.Exception);
+            return;
+        }
+
+        var pendingSecret = await _pendingSecretsService.ExtractPendingSecret(body.Environment, service,
+            body.SecretKey, "add_secret", cancellationToken);
+
+        if (pendingSecret != null)
+        {
+            await _secretsService.AddSecretKey(body.Environment, service,
+                pendingSecret.SecretKey, cancellationToken);
+
+            _logger.LogInformation("Add Secret: Added pending secret {SecretKey} in {Environment} to {Service}",
+                pendingSecret
+                    .SecretKey, body.Environment, service);
+        }
+        else
+        {
+            _logger.LogInformation("Add Secret: Secret {SecretKey} not found in pending secrets", body.SecretKey);
+        }
     }
     
     public static MessageHeader? TryParseMessageHeader(string body)

--- a/Defra.Cdp.Backend.Api/Services/Secrets/events/Message.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/events/Message.cs
@@ -27,6 +27,14 @@ public record BodyGetAllSecretKeys
     [JsonPropertyName("environment")] public string Environment { get; init; } = "";
 }
 
+public record BodyAddSecret
+{
+    [JsonPropertyName("secret")] public string SecretName { get; init; } = "";
+    [JsonPropertyName("secret_key")] public string SecretKey { get; init; } = "";
+    [JsonPropertyName("exception")] public string Exception { get; init; } = "";
+    [JsonPropertyName("environment")] public string Environment { get; init; } = "";
+}
+
 public record SecretKeysFromLambda
 {
     [JsonPropertyName("keys")] public List<string> Keys { get; init; } = new();

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -32,7 +32,7 @@
     "LogGroup": "cdp-portal-backend",
     "Region": "eu-west-2",
     "MinimumLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "Override": {
         "Microsoft": "Information",
         "System": "Information"

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -13,6 +13,9 @@
     "DatabaseUri": "mongodb://127.0.0.1:27017",
     "DatabaseName": "cdp-portal-backend"
   },
+  "Github": {
+    "PollIntervalSecs": 6000
+  },
   "DetailedErrors": true,
   "AllowedHosts": "*",
   "EcrEvents": {


### PR DESCRIPTION
API work to support secrets UI. Details in commit message:

- create `POST: /secrets/register/pending`
- create `GET: /secrets/{service}`
- handle secrets Lambda `add_secret` events
- create `pendingsecrets` collection with a 2 minute ttl