### PR TITLE
Creates missing deployments from lambda msg

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Models/DeploymentV2Tests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Models/DeploymentV2Tests.cs
@@ -82,9 +82,7 @@ public class DeploymentV2Tests
                 TaskCpu: 1024,
                 TaskMemory: 2048,
                 Environment: "infra-dev",
-                Zone: "protected",
-                DeployedBy: new EcsDeployedBy("12345678", "0", "test user"),
-                ServiceCode: "CDP"
+                DeployedBy: new EcsDeployedBy("0", "test user")
             )
         );
 

--- a/Defra.Cdp.Backend.Api.Tests/Models/DeploymentV2Tests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Models/DeploymentV2Tests.cs
@@ -45,4 +45,58 @@ public class DeploymentV2Tests
         deployment.TrimInstance(200);
         Assert.Equal(21, deployment.Instances.Count);
     }
+
+    [Fact]
+    public void TestExtractCommitSha()
+    {
+        var input =
+            "arn:aws:s3:::cdp-management-service-configs/e695d47d5d5a9bd9519b0b4c412c79f052d2c35a/global/global_fixed.env";
+        var result = DeploymentV2.ExtractCommitSha(input);
+        
+        Assert.Equal("e695d47d5d5a9bd9519b0b4c412c79f052d2c35a", result);
+    }
+    
+    [Fact]
+    public void TestExtractCommitShaWhenDataIsInvalid()
+    {
+        var input =
+            "arn:aws:s3:::cdp-management-service-configs/global/global_fixed.env";
+        var result = DeploymentV2.ExtractCommitSha(input);
+        
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TestCreteDeploymentFromLambda()
+    {
+        var lambda = new EcsDeploymentLambdaEvent(
+            "ECS Lambda Deployment Created",
+            "00000000",
+            new EcsDeploymentLambdaDetail("INFO", "CREATED", "ecs-svc/5730707953135730843", "reason"),
+            "12345678",
+            new EcsDeploymentLambdaRequest(
+                ContainerImage: "cdp-portal-backend",
+                ContainerVersion: "0.1.0",
+                DesiredCount: 1,
+                EnvFiles: [new EcsConfigFile("arn:aws:s3:::cdp-management-service-configs/e695d47d5d5a9bd9519b0b4c412c79f052d2c35a/global/global_fixed.env", "s3")],
+                TaskCpu: 1024,
+                TaskMemory: 2048,
+                Environment: "infra-dev",
+                Zone: "protected",
+                DeployedBy: new EcsDeployedBy("12345678", "0", "test user"),
+                ServiceCode: "CDP"
+            )
+        );
+
+        var deployment = DeploymentV2.FromLambdaMessage(lambda);
+        Assert.NotNull(deployment);
+        Assert.Equal(1, deployment.InstanceCount);
+        Assert.Equal("12345678", deployment.CdpDeploymentId);
+        Assert.Equal("cdp-portal-backend", deployment.Service);
+        Assert.Equal("0.1.0", deployment.Version);
+        Assert.Equal("1024", deployment.Cpu);
+        Assert.Equal("2048", deployment.Memory);
+        Assert.Equal("ecs-svc/5730707953135730843", deployment.LambdaId);
+        Assert.Equal("e695d47d5d5a9bd9519b0b4c412c79f052d2c35a", deployment.ConfigVersion);
+    }
 }

--- a/Defra.Cdp.Backend.Api.Tests/Models/UserServiceTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Models/UserServiceTests.cs
@@ -15,7 +15,7 @@ public class UserServiceTests
             "",
             "",
             "1234",
-            new()
+            []
         );
         
         var teamA2 = new UserServiceTeams(
@@ -25,10 +25,10 @@ public class UserServiceTests
             "",
             "",
             "9999",
-            new()
+            []
         );
         
-        var user = new UserServiceRecord("", new List<UserServiceTeams>() {teamA1, teamA2});
+        var user = new UserServiceRecord("", [teamA1, teamA2]);
         Assert.NotNull(user);
 
     }

--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/GenerateStatusTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/GenerateStatusTests.cs
@@ -14,18 +14,18 @@ public class GenerateStatusTests
     public void TestValidStatusPairs()
     {
         string[][] data =
-        {
+        [
             //      desired  last    expected
-            new[] { RUNNING, RUNNING, "in-progress" }, 
-            new[] { RUNNING, PENDING, "starting" },
-            new[] { RUNNING, PROVISIONING, "starting" },
-            new[] { RUNNING, STOPPED, "failed" },
-            new[] { STOPPED, STOPPING, "stopping" },
-            new[] { STOPPED, RUNNING, "stopping" },
-            new[] { STOPPED, PENDING, "stopping" },
-            new[] { STOPPED, PROVISIONING, "stopping" },
-            new[] { STOPPED, STOPPED, "finished" }
-        };
+            [RUNNING, RUNNING, "in-progress"], 
+            [RUNNING, PENDING, "starting"], 
+            [RUNNING, PROVISIONING, "starting"],
+            [RUNNING, STOPPED, "failed"],
+            [STOPPED, STOPPING, "stopping"],
+            [STOPPED, RUNNING, "stopping"],
+            [STOPPED, PENDING, "stopping"],
+            [STOPPED, PROVISIONING, "stopping"],
+            [STOPPED, STOPPED, "finished"]
+        ];
 
         foreach (var testcase in data)
         {

--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/LambdaHandlerTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/LambdaHandlerTests.cs
@@ -1,0 +1,139 @@
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.Aws.Deployments;
+using Defra.Cdp.Backend.Api.Services.Deployments;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Aws.Deployments;
+
+public class LambdaHandlerTests
+{
+    [Fact]
+    public async Task TestLambdaHandlerLinksExistingDeployment()
+    {
+        var service = Substitute.For<IDeploymentsServiceV2>();
+        var handler = new LambdaMessageHandlerV2(service, new NullLogger<LambdaMessageHandlerV2>());
+        
+        
+        var lambdaEvent = new EcsDeploymentLambdaEvent(
+            "ECS Lambda Deployment Created",
+            "00000000",
+            new EcsDeploymentLambdaDetail("INFO", "CREATED", "ecs-svc/5730707953135730843", "reason"),
+            "12345678",
+            new EcsDeploymentLambdaRequest(
+                ContainerImage: "cdp-portal-backend",
+                ContainerVersion: "0.1.0",
+                DesiredCount: 1,
+                EnvFiles: [new EcsConfigFile("arn:aws:s3:::cdp-management-service-configs/e695d47d5d5a9bd9519b0b4c412c79f052d2c35a/global/global_fixed.env", "s3")],
+                TaskCpu: 1024,
+                TaskMemory: 2048,
+                Environment: "infra-dev",
+                Zone: "protected",
+                DeployedBy: new EcsDeployedBy("12345678", "0", "test user"),
+                ServiceCode: "CDP"
+            )
+        );
+   
+        // setup mocks
+        var lookupResult = Task.FromResult<DeploymentV2?>(null); 
+        service.FindDeploymentByLambdaId(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(lookupResult);
+        service.LinkDeployment(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        service.UpdateDeploymentStatus(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        
+        await handler.Handle("1",  lambdaEvent, CancellationToken.None);
+
+        await service.Received().FindDeploymentByLambdaId("ecs-svc/5730707953135730843", Arg.Any<CancellationToken>());
+        await service.Received().LinkDeployment("12345678", "ecs-svc/5730707953135730843", Arg.Any<CancellationToken>());
+        await service.Received().UpdateDeploymentStatus("ecs-svc/5730707953135730843", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+    
+    [Fact]
+    public async Task TestLambdaHandlerNotUpdateAnExistingLink()
+    {
+        var service = Substitute.For<IDeploymentsServiceV2>();
+        var handler = new LambdaMessageHandlerV2(service, new NullLogger<LambdaMessageHandlerV2>());
+        
+        var lambdaEvent = new EcsDeploymentLambdaEvent(
+            "ECS Lambda Deployment Created",
+            "00000000",
+            new EcsDeploymentLambdaDetail("INFO", "CREATED", "ecs-svc/5730707953135730843", "reason"),
+            "12345678",
+            new EcsDeploymentLambdaRequest(
+                ContainerImage: "cdp-portal-backend",
+                ContainerVersion: "0.1.0",
+                DesiredCount: 1,
+                EnvFiles: [new EcsConfigFile("arn:aws:s3:::cdp-management-service-configs/e695d47d5d5a9bd9519b0b4c412c79f052d2c35a/global/global_fixed.env", "s3")],
+                TaskCpu: 1024,
+                TaskMemory: 2048,
+                Environment: "infra-dev",
+                Zone: "protected",
+                DeployedBy: new EcsDeployedBy("12345678", "0", "test user"),
+                ServiceCode: "CDP"
+            )
+        );
+   
+        // setup mocks
+        var lookupResult = Task.FromResult<DeploymentV2?>(new DeploymentV2()); 
+        service.FindDeploymentByLambdaId(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(lookupResult);
+        service.LinkDeployment(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        service.UpdateDeploymentStatus(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        
+        await handler.Handle("1",  lambdaEvent, CancellationToken.None);
+
+        await service.Received().FindDeploymentByLambdaId("ecs-svc/5730707953135730843", Arg.Any<CancellationToken>());
+        await service.DidNotReceive().LinkDeployment("12345678", "ecs-svc/5730707953135730843", Arg.Any<CancellationToken>());
+        await service.Received().UpdateDeploymentStatus("ecs-svc/5730707953135730843", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+    
+    [Fact]
+    public async Task TestLambdaHandlerCreateMissingDeployment()
+    {
+        // This would happen when the deployment originated from a different deployment of the portal
+        
+        var service = Substitute.For<IDeploymentsServiceV2>();
+        var handler = new LambdaMessageHandlerV2(service, new NullLogger<LambdaMessageHandlerV2>());
+        
+        var lambdaEvent = new EcsDeploymentLambdaEvent(
+            "ECS Lambda Deployment Created",
+            "00000000",
+            new EcsDeploymentLambdaDetail("INFO", "CREATED", "ecs-svc/5730707953135730843", "reason"),
+            "12345678",
+            new EcsDeploymentLambdaRequest(
+                ContainerImage: "cdp-portal-backend",
+                ContainerVersion: "0.1.0",
+                DesiredCount: 1,
+                EnvFiles: [new EcsConfigFile("arn:aws:s3:::cdp-management-service-configs/e695d47d5d5a9bd9519b0b4c412c79f052d2c35a/global/global_fixed.env", "s3")],
+                TaskCpu: 1024,
+                TaskMemory: 2048,
+                Environment: "infra-dev",
+                Zone: "protected",
+                DeployedBy: new EcsDeployedBy("12345678", "0", "test user"),
+                ServiceCode: "CDP"
+            )
+        );
+   
+        // setup mocks
+        var lookupResult = Task.FromResult<DeploymentV2?>(null); 
+        service.FindDeploymentByLambdaId(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(lookupResult);
+        
+        // fail linking as there's no existing deployment
+        service.LinkDeployment(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        service.RegisterDeployment(Arg.Any<DeploymentV2>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        
+        service.UpdateDeploymentStatus(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        
+        await handler.Handle("1",  lambdaEvent, CancellationToken.None);
+
+        await service.Received().FindDeploymentByLambdaId("ecs-svc/5730707953135730843", Arg.Any<CancellationToken>());
+        await service.Received().LinkDeployment("12345678", "ecs-svc/5730707953135730843", Arg.Any<CancellationToken>());
+        await service.Received().RegisterDeployment(Arg.Any<DeploymentV2>(), Arg.Any<CancellationToken>());
+        await service.Received().UpdateDeploymentStatus("ecs-svc/5730707953135730843", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/LambdaHandlerTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/LambdaHandlerTests.cs
@@ -28,9 +28,7 @@ public class LambdaHandlerTests
                 TaskCpu: 1024,
                 TaskMemory: 2048,
                 Environment: "infra-dev",
-                Zone: "protected",
-                DeployedBy: new EcsDeployedBy("12345678", "0", "test user"),
-                ServiceCode: "CDP"
+                DeployedBy: new EcsDeployedBy("0", "test user")
             )
         );
    
@@ -68,9 +66,7 @@ public class LambdaHandlerTests
                 TaskCpu: 1024,
                 TaskMemory: 2048,
                 Environment: "infra-dev",
-                Zone: "protected",
-                DeployedBy: new EcsDeployedBy("12345678", "0", "test user"),
-                ServiceCode: "CDP"
+                DeployedBy: new EcsDeployedBy("0", "test user")
             )
         );
    
@@ -110,9 +106,7 @@ public class LambdaHandlerTests
                 TaskCpu: 1024,
                 TaskMemory: 2048,
                 Environment: "infra-dev",
-                Zone: "protected",
-                DeployedBy: new EcsDeployedBy("12345678", "0", "test user"),
-                ServiceCode: "CDP"
+                DeployedBy: new EcsDeployedBy("0", "test user")
             )
         );
    

--- a/Defra.Cdp.Backend.Api.Tests/Services/Github/TemplatesLookupTest.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Github/TemplatesLookupTest.cs
@@ -16,7 +16,7 @@ public class TemplatesLookupTest
             { "TemplateMappings:cdp-dotnet-backend-template", "DotNet Backend" }
         };
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(myConfiguration)
+            .AddInMemoryCollection(myConfiguration!)
             .Build();
 
         var templatesLookup = new TemplatesFromConfig(configuration);

--- a/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
@@ -28,7 +28,7 @@ public class DeploymentV2
     public DateTime Updated { get; set; }
 
     public Dictionary<string, DeploymentInstanceStatus> Instances { get; set; } = new();
-    public string Status { get; set; }
+    public string Status { get; set; } = "";
     public bool Unstable { get; set; } = false;
 
     public string? ConfigVersion { get; init; } = default!;

--- a/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
@@ -59,9 +59,8 @@ public class DeploymentV2
     
     public static DeploymentV2? FromLambdaMessage(EcsDeploymentLambdaEvent e)
     {
-        
         var req = e.Request;
-        if (req == null)
+        if (req == null || e.CdpDeploymentId == null)
         {
             return null;
         }
@@ -70,7 +69,7 @@ public class DeploymentV2
         
         return new DeploymentV2
         {
-            CdpDeploymentId = e.CdpDeploymentId!,
+            CdpDeploymentId = e.CdpDeploymentId,
             Environment = req.Environment,
             Service = req.ContainerImage,
             Version = req.ContainerVersion,

--- a/Defra.Cdp.Backend.Api/Models/EcsDeploymentLambdaEvent.cs
+++ b/Defra.Cdp.Backend.Api/Models/EcsDeploymentLambdaEvent.cs
@@ -12,8 +12,8 @@ public sealed record EcsDeploymentLambdaEvent(
     EcsDeploymentLambdaDetail Detail,
     [property: JsonPropertyName("cdp_deployment_id")]
     string? CdpDeploymentId,
-    [property: JsonPropertyName("deployed_by")]
-    string? DeployedBy
+    [property: JsonPropertyName("cdp_request")]
+    EcsDeploymentLambdaRequest? Request
 );
 
 public sealed record EcsDeploymentLambdaDetail(
@@ -25,4 +25,40 @@ public sealed record EcsDeploymentLambdaDetail(
     string? EcsDeploymentId,
     [property: JsonPropertyName("reason")]
     string? Reason
+);
+
+public sealed record EcsConfigFile(
+    [property: JsonPropertyName("value")]
+    string Value, 
+    [property: JsonPropertyName("type")]
+    string Type
+    );
+
+public sealed record EcsDeployedBy(
+    string deployment_id,
+    string user_id,
+    string display_name
+    );
+
+public sealed record EcsDeploymentLambdaRequest(
+    [property: JsonPropertyName("container_image")]
+    string ContainerImage,
+    [property: JsonPropertyName("container_version")]
+    string ContainerVersion,
+    [property: JsonPropertyName("desired_count")]
+    int DesiredCount,
+    [property: JsonPropertyName("env_files")]
+    List<EcsConfigFile> EnvFiles,
+    [property: JsonPropertyName("task_cpu")]
+    int TaskCpu,
+    [property: JsonPropertyName("task_memory")]
+    int TaskMemory,
+    [property: JsonPropertyName("environment")]
+    string Environment,
+    [property: JsonPropertyName("zone")]
+    string Zone,
+    [property: JsonPropertyName("deployed_by")]
+    EcsDeployedBy DeployedBy,
+    [property: JsonPropertyName("service_code")]
+    string ServiceCode
 );

--- a/Defra.Cdp.Backend.Api/Models/EcsDeploymentLambdaEvent.cs
+++ b/Defra.Cdp.Backend.Api/Models/EcsDeploymentLambdaEvent.cs
@@ -35,7 +35,6 @@ public sealed record EcsConfigFile(
     );
 
 public sealed record EcsDeployedBy(
-    string deployment_id,
     string user_id,
     string display_name
     );
@@ -55,10 +54,6 @@ public sealed record EcsDeploymentLambdaRequest(
     int TaskMemory,
     [property: JsonPropertyName("environment")]
     string Environment,
-    [property: JsonPropertyName("zone")]
-    string Zone,
     [property: JsonPropertyName("deployed_by")]
-    EcsDeployedBy DeployedBy,
-    [property: JsonPropertyName("service_code")]
-    string ServiceCode
+    EcsDeployedBy DeployedBy
 );


### PR DESCRIPTION
This requires the deployment lambda to be updated to return the payload it was triggerd with.
If we fail to find the corresponding CDP id for this message we can assume it did originated from a different portal. Using the new request data we can generate an almost complete deployment record for it and save it.