### PR TITLE
Fallback for linking tasks on TaskArn

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/TaskStateChangeEventHandlerTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/TaskStateChangeEventHandlerTests.cs
@@ -1,0 +1,133 @@
+using Defra.Cdp.Backend.Api.Config;
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.Aws;
+using Defra.Cdp.Backend.Api.Services.Aws.Deployments;
+using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.TenantArtifacts;
+using Defra.Cdp.Backend.Api.Services.TestSuites;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ReceivedExtensions;
+using NSubstitute.ReturnsExtensions;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Aws.Deployments;
+
+class MockEnvironmentLookup : IEnvironmentLookup
+{
+    public string? FindEnv(string account)
+    {
+        return "test";
+    }
+}
+
+public class TaskStateChangeEventHandlerTests
+{
+    private readonly EcsTaskStateChangeEvent _testEvent = new EcsTaskStateChangeEvent(
+        "12345", 
+        "ECS Task State Change",
+        "1111111111",
+        DateTime.Now,
+        "eu-west-2",
+        new EcsEventDetail(
+            DateTime.Now, 
+            "1024", 
+            "1024", 
+            "RUNNING", 
+            "RUNNING",
+            [],
+            "arn:aws:ecs:eu-west-2:506190012364:task-definition/cdp-example-node-backend:47",
+            "task-arn",
+            "reason",
+            "ecs-svc/6276605373259507742",
+            "ecs-svc/6276605373259507742"),
+        "ecs-svc/6276605373259507742",
+        "ecs-svc/6276605373259507742"
+    );
+
+    
+    [Fact]
+    public async Task TestUpdatesUsingLinkedRecord()
+    {
+
+        var config = new OptionsWrapper<EcsEventListenerOptions>(new EcsEventListenerOptions());
+        
+        var deployablesService = Substitute.For<IDeployablesService>();
+        var deploymentsService = Substitute.For<IDeploymentsServiceV2>();
+        var testRunService = Substitute.For<ITestRunService>();
+
+        deploymentsService.FindDeploymentByLambdaId("ecs-svc/6276605373259507742", Arg.Any<CancellationToken>())
+            .Returns(new DeploymentV2());
+        
+        var handler = new TaskStateChangeEventHandler(config, 
+            new MockEnvironmentLookup(),
+            deploymentsService, 
+            deployablesService, 
+            testRunService,
+            ConsoleLogger.CreateLogger<TaskStateChangeEventHandler>());
+        
+        await handler.UpdateDeployment(_testEvent, new CancellationToken());
+        
+        await deploymentsService.Received().FindDeploymentByLambdaId("ecs-svc/6276605373259507742", Arg.Any<CancellationToken>());
+        await deploymentsService.DidNotReceiveWithAnyArgs().FindDeploymentByTaskArn(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await deploymentsService.Received().UpdateDeployment(Arg.Any<DeploymentV2>(), Arg.Any<CancellationToken>());
+    }
+    
+    [Fact]
+    public async Task TestFallbackLinking()
+    {
+
+        var config = new OptionsWrapper<EcsEventListenerOptions>(new EcsEventListenerOptions());
+        
+        var deployablesService = Substitute.For<IDeployablesService>();
+        var deploymentsService = Substitute.For<IDeploymentsServiceV2>();
+        var testRunService = Substitute.For<ITestRunService>();
+
+        deploymentsService.FindDeploymentByLambdaId("ecs-svc/6276605373259507742", Arg.Any<CancellationToken>()).ReturnsNull();
+        deploymentsService.FindDeploymentByTaskArn("arn:aws:ecs:eu-west-2:506190012364:task-definition/cdp-example-node-backend:47", Arg.Any<CancellationToken>()).Returns(new DeploymentV2());
+        
+        
+        var handler = new TaskStateChangeEventHandler(config, 
+            new MockEnvironmentLookup(),
+            deploymentsService, 
+            deployablesService, 
+            testRunService,
+            ConsoleLogger.CreateLogger<TaskStateChangeEventHandler>());
+        
+        await handler.UpdateDeployment(_testEvent, new CancellationToken());
+        
+        await deploymentsService.Received().FindDeploymentByLambdaId("ecs-svc/6276605373259507742", Arg.Any<CancellationToken>());
+        await deploymentsService.Received().FindDeploymentByTaskArn("arn:aws:ecs:eu-west-2:506190012364:task-definition/cdp-example-node-backend:47", Arg.Any<CancellationToken>());
+        await deploymentsService.Received().UpdateDeployment(Arg.Any<DeploymentV2>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TestNotUpdatedWhenNoLinkExists()
+    {
+
+        var config = new OptionsWrapper<EcsEventListenerOptions>(new EcsEventListenerOptions());
+        
+        var deployablesService = Substitute.For<IDeployablesService>();
+        var deploymentsService = Substitute.For<IDeploymentsServiceV2>();
+        var testRunService = Substitute.For<ITestRunService>();
+
+        deploymentsService.FindDeploymentByLambdaId("ecs-svc/6276605373259507742", Arg.Any<CancellationToken>()).ReturnsNull();
+        deploymentsService
+            .FindDeploymentByTaskArn("arn:aws:ecs:eu-west-2:506190012364:task-definition/cdp-example-node-backend:47",
+                Arg.Any<CancellationToken>()).ReturnsNull();
+        
+        
+        var handler = new TaskStateChangeEventHandler(config, 
+            new MockEnvironmentLookup(),
+            deploymentsService, 
+            deployablesService, 
+            testRunService,
+            ConsoleLogger.CreateLogger<TaskStateChangeEventHandler>());
+
+        await handler.UpdateDeployment(_testEvent, new CancellationToken());
+        
+        await deploymentsService.Received().FindDeploymentByLambdaId("ecs-svc/6276605373259507742", Arg.Any<CancellationToken>());
+        await deploymentsService.Received().FindDeploymentByTaskArn("arn:aws:ecs:eu-west-2:506190012364:task-definition/cdp-example-node-backend:47", Arg.Any<CancellationToken>());
+        await deploymentsService.DidNotReceive().UpdateDeployment(Arg.Any<DeploymentV2>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
@@ -38,6 +38,8 @@ public class DeploymentV2
     public string? LastDeploymentStatus { get; set; }
     public string? LastDeploymentMessage { get; set; }
     
+    public string? TaskDefinitionArn { get; set; }
+    
     public static DeploymentV2 FromRequest(RequestedDeployment req)
     {
         return new DeploymentV2


### PR DESCRIPTION
If the event's ecs deployment id doesn't match any record in portal, attempt to link the records up by task-def arn