### PR TITLE
Find test suite with test run

### DIFF
--- a/Defra.Cdp.Backend.Api/Endpoints/TestSuiteEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/TestSuiteEndpoint.cs
@@ -71,7 +71,7 @@ public static class TestSuiteEndpoint
 
    private sealed record TestSuiteWithLatestJobResponse(
     ServiceInfo testSuite,
-    TestRun? LatestTestRun
+    TestRun? LastRun
     )
    {
    }

--- a/Defra.Cdp.Backend.Api/Services/TestSuites/TestRunService.cs
+++ b/Defra.Cdp.Backend.Api/Services/TestSuites/TestRunService.cs
@@ -8,6 +8,7 @@ public interface ITestRunService
 {
     public Task<TestRun?> FindTestRun(string runId, CancellationToken cancellationToken);
     public Task<List<TestRun>> FindTestRunsForTestSuite(string suite, CancellationToken cancellationToken, int limit);
+    public Task<TestRun?> FindLatestTestRunForTestSuite(string suite, CancellationToken cancellationToken);
     public Task<TestRun?> FindByTaskArn(string taskArn, CancellationToken cancellationToken);
     public Task CreateTestRun(TestRun testRun, CancellationToken cancellationToken);
     public Task<TestRun?> Link(TestRunMatchIds ids,  DeployableArtifact artifact, string taskArn, CancellationToken cancellationToken);
@@ -40,6 +41,12 @@ public class TestRunService : MongoService<TestRun>, ITestRunService
     {
         return await Collection.Find(t => t.TestSuite == suite).SortByDescending(t=>t.Created).Limit(limit).ToListAsync(cancellationToken);
     }
+
+
+   public async Task<TestRun?> FindLatestTestRunForTestSuite(string suite, CancellationToken cancellationToken)
+   {
+      return await Collection.Find(t => t.TestSuite == suite).SortByDescending(t => t.Created).FirstOrDefaultAsync(cancellationToken);
+   }
 
     public async Task<TestRun?> FindByTaskArn(string taskArn, CancellationToken cancellationToken)
     {

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -37,7 +37,8 @@
         "Microsoft": "Information",
         "System": "Warning",
         "Quartz": "Warning",
-        "Defra.Cdp.Backend.Api.Mongo": "Warning",
+        "Defra.Cdp.Backend.Api.Mongo": "Information",
+        "Defra.Cdp.Backend.Api.Mongo.MongoLock": "Warning",
         "Defra.Cdp.Backend.Api.Services.Github": "Warning",
         "Defra.Cdp.Backend.Api": "Debug"
       }


### PR DESCRIPTION
Adds a new endpoint `/test-suite/test-run` which returns all test suits enriched with the latest test run.