### PR TITLE
468652 trigger other runs

### DIFF
--- a/Defra.Cdp.Backend.Api/Models/DeploymentTrigger.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeploymentTrigger.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Bson.Serialization.IdGenerators;
+
+namespace Defra.Cdp.Backend.Api.Models;
+
+
+public record DeploymentTrigger
+{
+   [BsonId(IdGenerator = typeof(ObjectIdGenerator))]
+   [property: JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+   public ObjectId? Id { get; init; } = default!;
+
+   public DateTime Created { get; init; } = DateTime.Now;
+
+   [property: JsonPropertyName("repository")]
+   public string Repository { get; init; } = default!;
+
+   [property: JsonPropertyName("testSuite")]
+   public string TestSuite { get; init; } = default!;
+
+   [property: JsonPropertyName("environments")]
+   public List<string> Environments { get; init; } = new();
+
+}

--- a/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeploymentV2.cs
@@ -38,6 +38,8 @@ public class DeploymentV2
     public string? LastDeploymentStatus { get; set; }
     public string? LastDeploymentMessage { get; set; }
     
+    public List<TestRun> DeploymentTestRuns { get; set; } = new();
+
     public string? TaskDefinitionArn { get; set; }
     
     public static DeploymentV2 FromRequest(RequestedDeployment req)

--- a/Defra.Cdp.Backend.Api/Models/TestRun.cs
+++ b/Defra.Cdp.Backend.Api/Models/TestRun.cs
@@ -40,4 +40,17 @@ public sealed class TestRun
     
     [property: JsonPropertyName("tag")]
     public string? Tag { get; set; }
+
+   public static TestRun FromDeployment(DeploymentV2 deployment, string testSuite)
+   {
+      return new TestRun
+      {
+         RunId = Guid.NewGuid().ToString(),
+         TestSuite = testSuite,
+         Environment = deployment.Environment,
+         User = deployment.User ?? null,
+         Created = DateTime.Now
+      };
+   }
+
 }

--- a/Defra.Cdp.Backend.Api/Program.cs
+++ b/Defra.Cdp.Backend.Api/Program.cs
@@ -8,6 +8,7 @@ using Defra.Cdp.Backend.Api.Services.Actions;
 using Defra.Cdp.Backend.Api.Services.Aws;
 using Defra.Cdp.Backend.Api.Services.Aws.Deployments;
 using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.DeploymentTriggers;
 using Defra.Cdp.Backend.Api.Services.Github;
 using Defra.Cdp.Backend.Api.Services.Github.ScheduledTasks;
 using Defra.Cdp.Backend.Api.Services.Secrets;
@@ -153,6 +154,8 @@ builder.Services.AddSingleton<ActionEventListener>();
 
 // Pending Secrets
 builder.Services.AddSingleton<IPendingSecretsService, PendingSecretsService>();
+
+builder.Services.AddSingleton<IDeploymentTriggerService, DeploymentTriggerService>();
 
 builder.Services.AddSingleton<MongoLock>();
 

--- a/Defra.Cdp.Backend.Api/Program.cs
+++ b/Defra.Cdp.Backend.Api/Program.cs
@@ -143,6 +143,9 @@ builder.Services.AddSingleton<TaskStateChangeEventHandler>();
 builder.Services.AddSingleton<DeploymentStateChangeEventHandler>();
 builder.Services.AddSingleton<LambdaMessageHandlerV2>();
 
+// Deployment Trigger Event Handlers
+builder.Services.AddSingleton<DeploymentTriggerEventHandler>();
+
 // Secret Event Handlers
 builder.Services.AddSingleton<ISecretsService, SecretsService>();
 builder.Services.AddSingleton<ISecretEventHandler, SecretEventHandler>();

--- a/Defra.Cdp.Backend.Api/Properties/launchSettings.json
+++ b/Defra.Cdp.Backend.Api/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "profiles": {
     "Backend.Api": {
       "commandName": "Project",
@@ -26,7 +26,8 @@
         "AzureAd__ClientId": "63983fc2-cfff-45bb-8ec2-959e21062b9a",
         "Github__AppKey": "// generate a random key for local testing using `ssh-keygen -t rsa -b 4096 -m PEM -f /tmp/mock.key -q -P '' && cat /tmp/mock.key | base64 -w0`",
         "Github__ApiUrl": "http://localhost:3939",
-        "UserServiceBackendUrl": "http://localhost:3001"
+        "UserServiceBackendUrl": "http://localhost:3001",
+        "SelfServiceOpsUrl": "http://localhost:3009"
       }
     }
   }

--- a/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
@@ -35,7 +35,7 @@ public class DeploymentStateChangeEventHandler
         }
       else
       {
-         var deployment = await _deploymentsService.FindDeployment(ecsEvent.Detail.DeploymentId, cancellationToken);
+         var deployment = await _deploymentsService.FindDeploymentByLambdaId(ecsEvent.Detail.DeploymentId, cancellationToken);
          if (deployment == null)
          {
             _logger.LogWarning("{id} Deployment {deploymentId} not found", id, ecsEvent.Detail.DeploymentId);

--- a/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
@@ -46,7 +46,7 @@ public class DeploymentStateChangeEventHandler
          }
          else 
          {
-            var deploymentTriggers = await _deploymentTriggerService.FindDeploymentTriggers(deployment.Service, cancellationToken);
+            var deploymentTriggers = await _deploymentTriggerService.FindTriggersForDeployment(deployment, cancellationToken);
 
             foreach (var trigger in deploymentTriggers)
             {

--- a/Defra.Cdp.Backend.Api/Services/Aws/EcsEventListener.cs
+++ b/Defra.Cdp.Backend.Api/Services/Aws/EcsEventListener.cs
@@ -4,6 +4,7 @@ using Amazon.SQS.Model;
 using Defra.Cdp.Backend.Api.Config;
 using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Services.Aws.Deployments;
+using Defra.Cdp.Backend.Api.Services.DeploymentTriggers;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
@@ -16,6 +17,7 @@ public class EcsEventListener(
     TaskStateChangeEventHandler taskStateChangeEventHandler,
     LambdaMessageHandlerV2 lambdaMessageHandlerV2,
     DeploymentStateChangeEventHandler deploymentStateChangeEventHandler,
+    DeploymentTriggerEventHandler deploymentTriggerEventHandler,
     ILogger<EcsEventListener> logger)
     : SqsListener(sqs, config.Value.QueueUrl, logger)
 {
@@ -76,6 +78,7 @@ public class EcsEventListener(
                 }
                 
                 await deploymentStateChangeEventHandler.Handle(id, ecsDeploymentEvent, cancellationToken);
+                await deploymentTriggerEventHandler.Handle(id, ecsDeploymentEvent, cancellationToken);
                 break;
             default:
                 logger.LogInformation("Not processing {Id}, no handler for {messageType}. message was {MessageBody}",

--- a/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerEventHandler.cs
@@ -48,7 +48,7 @@ public class DeploymentTriggerEventHandler
          {
             _logger.LogInformation("{id} Triggering test run for {deploymentId} {testSuite}", id, ecsEvent.Detail.DeploymentId, trigger.TestSuite);
 
-            await _selfServiceOpsFetcher.triggerTestSuite(trigger.TestSuite, deployment.Environment, cancellationToken);
+            await _selfServiceOpsFetcher.triggerTestSuite(trigger.TestSuite, deployment.Environment, deployment.User, cancellationToken);
 
          }
       }

--- a/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerEventHandler.cs
@@ -1,4 +1,5 @@
 using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.Aws.Deployments;
 using Defra.Cdp.Backend.Api.Services.Deployments;
 using Defra.Cdp.Backend.Api.Services.DeploymentTriggers;
 using Defra.Cdp.Backend.Api.Services.TestSuites;
@@ -47,7 +48,7 @@ public class DeploymentTriggerEventHandler
          {
             _logger.LogInformation("{id} Triggering test run for {deploymentId} {testSuite}", id, ecsEvent.Detail.DeploymentId, trigger.TestSuite);
 
-            await _selfServiceOpsFetcher.triggerTestSuite(deployment.Service, deployment.Environment, cancellationToken);
+            await _selfServiceOpsFetcher.triggerTestSuite(trigger.TestSuite, deployment.Environment, cancellationToken);
 
          }
       }

--- a/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerEventHandler.cs
@@ -1,0 +1,55 @@
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.DeploymentTriggers;
+using Defra.Cdp.Backend.Api.Services.TestSuites;
+
+namespace Defra.Cdp.Backend.Api.Services.DeploymentTriggers;
+
+public class DeploymentTriggerEventHandler
+{
+   private readonly IDeploymentsServiceV2 _deploymentsService;
+   private readonly IDeploymentTriggerService _deploymentTriggerService;
+   private readonly SelfServiceOpsFetcher _selfServiceOpsFetcher;
+   private readonly ILogger<DeploymentTriggerEventHandler> _logger;
+
+   public DeploymentTriggerEventHandler(
+     IConfiguration configuration,
+     IDeploymentsServiceV2 deploymentsService,
+     IDeploymentTriggerService deploymentTriggerService,
+     ILogger<DeploymentTriggerEventHandler> logger
+  )
+   {
+      _deploymentsService = deploymentsService;
+      _deploymentTriggerService = deploymentTriggerService;
+      _logger = logger;
+      _selfServiceOpsFetcher = new SelfServiceOpsFetcher(configuration);
+   }
+
+   public async Task Handle(string id, EcsDeploymentStateChangeEvent ecsEvent, CancellationToken cancellationToken)
+   {
+      _logger.LogInformation("{id} Handling EcsDeploymentStateChange trigger test runs for {deploymentId}, {name} {reason}",
+       id, ecsEvent.Detail.DeploymentId, ecsEvent.Detail.EventName, ecsEvent.Detail.Reason);
+
+      var deployment = await _deploymentsService.FindDeploymentByLambdaId(ecsEvent.Detail.DeploymentId, cancellationToken);
+      if (deployment == null)
+      {
+         _logger.LogWarning("{id} Deployment {deploymentId} not found", id, ecsEvent.Detail.DeploymentId);
+      }
+      else if (deployment.Status != DeploymentStatus.Running)
+      {
+         _logger.LogWarning("{id} Deployment {deploymentId} not running", id, ecsEvent.Detail.DeploymentId);
+      }
+      else
+      {
+         var deploymentTriggers = await _deploymentTriggerService.FindTriggersForDeployment(deployment, cancellationToken);
+
+         foreach (var trigger in deploymentTriggers)
+         {
+            _logger.LogInformation("{id} Triggering test run for {deploymentId} {testSuite}", id, ecsEvent.Detail.DeploymentId, trigger.TestSuite);
+
+            await _selfServiceOpsFetcher.triggerTestSuite(deployment.Service, deployment.Environment, cancellationToken);
+
+         }
+      }
+   }
+}

--- a/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerService.cs
+++ b/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerService.cs
@@ -6,10 +6,7 @@ namespace Defra.Cdp.Backend.Api.Services.DeploymentTriggers;
 
 public interface IDeploymentTriggerService
 {
-   public Task<List<DeploymentTrigger>> FindDeploymentTriggers(string repository, CancellationToken cancellationToken);
-
-   public Task<DeploymentTrigger?> FindDeploymentTrigger(string repository, string testSuite, CancellationToken cancellationToken);
-
+   public Task<List<DeploymentTrigger>> FindTriggersForDeployment(DeploymentV2 deployment, CancellationToken cancellationToken);
 }
 
 public class DeploymentTriggerService : MongoService<DeploymentTrigger>, IDeploymentTriggerService
@@ -29,15 +26,10 @@ public class DeploymentTriggerService : MongoService<DeploymentTrigger>, IDeploy
       return [repositoryIndex, testSuiteIndex];
    }
 
-   public async Task<List<DeploymentTrigger>> FindDeploymentTriggers(string repository, CancellationToken cancellationToken)
+   public async Task<List<DeploymentTrigger>> FindTriggersForDeployment(DeploymentV2 deployment, CancellationToken cancellationToken)
    {
-      return await Collection.Find(t => t.Repository == repository).ToListAsync(cancellationToken);
-   }
-
-   public async Task<DeploymentTrigger?> FindDeploymentTrigger(string repository, string testSuite, CancellationToken cancellationToken)
-   {
-      return await Collection.Find(t => t.Repository == repository && t.TestSuite == testSuite)
-         .FirstOrDefaultAsync(cancellationToken);
+      return await Collection.Find(t => t.Repository == deployment.Service && t.Environments.Contains(deployment.Environment))
+         .ToListAsync(cancellationToken);
    }
 
 }

--- a/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerService.cs
+++ b/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/DeploymentTriggerService.cs
@@ -1,0 +1,43 @@
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Mongo;
+using MongoDB.Driver;
+
+namespace Defra.Cdp.Backend.Api.Services.DeploymentTriggers;
+
+public interface IDeploymentTriggerService
+{
+   public Task<List<DeploymentTrigger>> FindDeploymentTriggers(string repository, CancellationToken cancellationToken);
+
+   public Task<DeploymentTrigger?> FindDeploymentTrigger(string repository, string testSuite, CancellationToken cancellationToken);
+
+}
+
+public class DeploymentTriggerService : MongoService<DeploymentTrigger>, IDeploymentTriggerService
+{
+   private const string CollectionName = "deploymenttriggers";
+
+   public DeploymentTriggerService(IMongoDbClientFactory connectionFactory,
+      ILoggerFactory loggerFactory) : base(connectionFactory, CollectionName, loggerFactory)
+   {
+   }
+
+   protected override List<CreateIndexModel<DeploymentTrigger>> DefineIndexes(IndexKeysDefinitionBuilder<DeploymentTrigger> builder)
+   {
+      var repositoryIndex = new CreateIndexModel<DeploymentTrigger>(builder.Ascending(t => t.Repository));
+      var testSuiteIndex = new CreateIndexModel<DeploymentTrigger>(builder.Ascending(t => t.TestSuite));
+
+      return [repositoryIndex, testSuiteIndex];
+   }
+
+   public async Task<List<DeploymentTrigger>> FindDeploymentTriggers(string repository, CancellationToken cancellationToken)
+   {
+      return await Collection.Find(t => t.Repository == repository).ToListAsync(cancellationToken);
+   }
+
+   public async Task<DeploymentTrigger?> FindDeploymentTrigger(string repository, string testSuite, CancellationToken cancellationToken)
+   {
+      return await Collection.Find(t => t.Repository == repository && t.TestSuite == testSuite)
+         .FirstOrDefaultAsync(cancellationToken);
+   }
+
+}

--- a/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/SelfServiceOpsFetcher.cs
+++ b/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/SelfServiceOpsFetcher.cs
@@ -23,7 +23,7 @@ public class SelfServiceOpsFetcher
           "cdp-portal-backend");
    }
 
-   public async Task<HttpStatusCode> deployTestSuite(string ImageName, string Environment, CancellationToken cancellationToken)
+   public async Task<HttpStatusCode> triggerTestSuite(string ImageName, string Environment, CancellationToken cancellationToken)
    {
       var body = new
       {
@@ -31,7 +31,7 @@ public class SelfServiceOpsFetcher
          environment = Environment
       };
       var payload = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-      var result = await _client.PostAsync("/run-test-suite", payload, cancellationToken);
+      var result = await _client.PostAsync("/trigger-test-suite", payload, cancellationToken);
       result.EnsureSuccessStatusCode();
       return result.StatusCode;
    }

--- a/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/SelfServiceOpsFetcher.cs
+++ b/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/SelfServiceOpsFetcher.cs
@@ -23,12 +23,13 @@ public class SelfServiceOpsFetcher
           "cdp-portal-backend");
    }
 
-   public async Task<HttpStatusCode> triggerTestSuite(string ImageName, string Environment, CancellationToken cancellationToken)
+   public async Task<HttpStatusCode> triggerTestSuite(string ImageName, string Environment, UserDetails? User, CancellationToken cancellationToken)
    {
       var body = new
       {
          imageName = ImageName,
-         environment = Environment
+         environment = Environment,
+         user = User
       };
       var payload = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
       var result = await _client.PostAsync("/trigger-test-suite", payload, cancellationToken);

--- a/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/SelfServiceOpsFetcher.cs
+++ b/Defra.Cdp.Backend.Api/Services/DeploymentTriggers/SelfServiceOpsFetcher.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Defra.Cdp.Backend.Api.Models;
+
+namespace Defra.Cdp.Backend.Api.Services.DeploymentTriggers;
+
+public class SelfServiceOpsFetcher
+{
+   private readonly HttpClient _client;
+
+   public SelfServiceOpsFetcher(IConfiguration configuration)
+   {
+      var selfServiceOpsUrl = configuration.GetValue<string>("SelfServiceOpsUrl")!;
+      if (string.IsNullOrWhiteSpace(selfServiceOpsUrl))
+         throw new ArgumentNullException("selfServiceOpsBackendUrl", "Self service ops backend url cannot be null");
+      _client = new HttpClient();
+      _client.BaseAddress = new Uri(selfServiceOpsUrl);
+      _client.DefaultRequestHeaders.Accept.Clear();
+      _client.DefaultRequestHeaders.Add(
+          "Accept", "application/json");
+      _client.DefaultRequestHeaders.Add("User-Agent",
+          "cdp-portal-backend");
+   }
+
+   public async Task<HttpStatusCode> deployTestSuite(string ImageName, string Environment, CancellationToken cancellationToken)
+   {
+      var body = new
+      {
+         imageName = ImageName,
+         environment = Environment
+      };
+      var payload = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+      var result = await _client.PostAsync("/run-test-suite", payload, cancellationToken);
+      result.EnsureSuccessStatusCode();
+      return result.StatusCode;
+   }
+}

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -35,6 +35,8 @@
       "Default": "Debug",
       "Override": {
         "Microsoft": "Information",
+        "Microsoft.AspNetCore.Hosting": "Warning",
+        "Microsoft.AspNetCore.Http": "Warning",
         "System": "Warning",
         "Quartz": "Warning",
         "Defra.Cdp.Backend.Api.Mongo": "Information",

--- a/Defra.Cdp.Backend.Api/appsettings.json
+++ b/Defra.Cdp.Backend.Api/appsettings.json
@@ -21,6 +21,7 @@
     "ApiUrl": "https://api.github.com"
   },
   "UserServiceBackendUrl": "http://localhost:3001",
+  "SelfServiceOpsUrl": "http://localhost:3009",
   "AzureAdminGroupId": "group1",
   "DetailedErrors": true,
   "AllowedHosts": "*",


### PR DESCRIPTION
Listens on deployment events and then looks up triggers for test suites.

The Mongodb needs an entry like
```
db.deploymenttriggers.updateOne(
  {
    repository: "cdp-portal-frontend",
    testSuite: "cdp-env-test-suite",
    environment: "perf-test",
  },
  {
    $setOnInsert: {
      created: "2023-10-01T12:27:57.452Z",
      repository: "cdp-portal-frontend",
      testSuite: "cdp-env-test-suite",
      environments: ["infra-dev"],
    },
  },
  { upsert: true }
);
```