### PR TITLE
411709: Add service filters

### DIFF
--- a/Defra.Cdp.Backend.Api/Endpoints/TestSuiteEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/TestSuiteEndpoint.cs
@@ -52,7 +52,7 @@ public static class TestSuiteEndpoint
         [FromServices] ITestRunService testRunService, CancellationToken cancellationToken)
    {
        var testSuites =
-           await deployableArtifactsService.FindAllServices(ArtifactRunMode.Job, teamId, cancellationToken);
+           await deployableArtifactsService.FindAllServices(ArtifactRunMode.Job, teamId, null, cancellationToken);
       var latestTestRuns = await testRunService.FindLatestTestRuns(cancellationToken);
       var testSuiteWithLatestJobResponses = testSuites.Select(ts =>
       {

--- a/Defra.Cdp.Backend.Api/Models/Filters.cs
+++ b/Defra.Cdp.Backend.Api/Models/Filters.cs
@@ -7,3 +7,9 @@ public sealed class DeploymentFilters
     public List<UserDetails> Users { get; init; } = default!;
     public List<RepositoryTeam> Teams { get; set; } = default!;
 }
+
+public sealed class ServiceFilters
+{
+    public List<string> Services { get; init; } = default!;
+    public List<RepositoryTeam> Teams { get; set; } = default!;
+}

--- a/Defra.Cdp.Backend.Api/Services/Deployments/DeploymentsServiceV2.cs
+++ b/Defra.Cdp.Backend.Api/Services/Deployments/DeploymentsServiceV2.cs
@@ -149,7 +149,8 @@ public class DeploymentsServiceV2 : MongoService<DeploymentV2>, IDeploymentsServ
 
         if (!string.IsNullOrWhiteSpace(service))
         {
-            var partialServiceFilter = Builders<DeploymentV2>.Filter.Regex(d => d.Service,  new BsonRegularExpression($"^{service}", "i"));
+            var partialServiceFilter =
+                Builders<DeploymentV2>.Filter.Regex(d => d.Service,  new BsonRegularExpression(service, "i"));
             filter &= partialServiceFilter;
         }
         

--- a/Defra.Cdp.Backend.Api/Services/TenantArtifacts/DeployableArtifactService.cs
+++ b/Defra.Cdp.Backend.Api/Services/TenantArtifacts/DeployableArtifactService.cs
@@ -147,7 +147,7 @@ public class DeployableArtifactsService(IMongoDbClientFactory connectionFactory,
         if (!string.IsNullOrWhiteSpace(service))
         {
             var partialServiceFilter =
-                builder.Regex(d => d.ServiceName,  new BsonRegularExpression($"^{service}", "i"));
+                builder.Regex(d => d.ServiceName,  new BsonRegularExpression(service, "i"));
             filter &= partialServiceFilter;
         }
 


### PR DESCRIPTION
- Add in service filters endpoint to provide filters for the service page, for `team` and `service`
- Add query params for service to support providing results for these query params when filters are used on the services list page