### PR TITLE
Removes tag lookup from ecs test handler

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/UpdateTestSuiteTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/UpdateTestSuiteTests.cs
@@ -76,7 +76,6 @@ public class UpdateTestSuiteTests
         _testRunService.FindByTaskArn(Arg.Any<string>(), Arg.Any<CancellationToken>()).ReturnsNull();
         _testRunService.Link(
             Arg.Any<TestRunMatchIds>(),
-            Arg.Any<DeployableArtifact>(),
             ecsEvent.Detail.TaskArn,
             Arg.Any<CancellationToken>()
         ).Returns(new TestRun

--- a/Defra.Cdp.Backend.Api/Services/Aws/Deployments/TaskStateChangeEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Aws/Deployments/TaskStateChangeEventHandler.cs
@@ -157,7 +157,6 @@ public class TaskStateChangeEventHandler(
                 logger.LogInformation("trying to link {id}", artifact.ServiceName);
                 testRun = await testRunService.Link(
                     new TestRunMatchIds(artifact.ServiceName!, env!, ecsTaskStateChangeEvent.Timestamp), 
-                    artifact,
                     taskArn, 
                     cancellationToken);
             }

--- a/Defra.Cdp.Backend.Api/Services/TestSuites/TestRunService.cs
+++ b/Defra.Cdp.Backend.Api/Services/TestSuites/TestRunService.cs
@@ -11,7 +11,7 @@ public interface ITestRunService
     public Task<Dictionary<string, TestRun>> FindLatestTestRuns(CancellationToken cancellationToken);
     public Task<TestRun?> FindByTaskArn(string taskArn, CancellationToken cancellationToken);
     public Task CreateTestRun(TestRun testRun, CancellationToken cancellationToken);
-    public Task<TestRun?> Link(TestRunMatchIds ids,  DeployableArtifact artifact, string taskArn, CancellationToken cancellationToken);
+    public Task<TestRun?> Link(TestRunMatchIds ids, string taskArn, CancellationToken cancellationToken);
     public Task UpdateStatus(string taskArn, string taskStatus, string? testStatus, DateTime ecsEventTimestamp, List<FailureReason> failureReasons, CancellationToken cancellationToken);
     Task Decommission(string serviceName, CancellationToken cancellationToken);
 }
@@ -64,7 +64,7 @@ public class TestRunService : MongoService<TestRun>, ITestRunService
         await Collection.InsertOneAsync(testRun, new InsertOneOptions(), cancellationToken);
    }
 
-    public async Task<TestRun?> Link(TestRunMatchIds ids, DeployableArtifact artifact, string taskArn, CancellationToken cancellationToken)
+    public async Task<TestRun?> Link(TestRunMatchIds ids, string taskArn, CancellationToken cancellationToken)
     {
         var fb = new FilterDefinitionBuilder<TestRun>();
 
@@ -78,8 +78,7 @@ public class TestRunService : MongoService<TestRun>, ITestRunService
 
         var update = Builders<TestRun>
             .Update
-            .Set(d => d.TaskArn, taskArn)
-            .Set(d => d.Tag, artifact.Tag);
+            .Set(d => d.TaskArn, taskArn);
 
         return await Collection.FindOneAndUpdateAsync(filter, update, cancellationToken: cancellationToken);
     }


### PR DESCRIPTION
SSOps has been updated to provide the actual tag version (x.y.z vs latest) when the test run is created.