### PR TITLE
CORE-317: Get CPU and Memory for Auto Test Runs

### DIFF
--- a/Defra.Cdp.Backend.Api/Models/TestRunSettings.cs
+++ b/Defra.Cdp.Backend.Api/Models/TestRunSettings.cs
@@ -1,0 +1,7 @@
+namespace Defra.Cdp.Backend.Api.Models;
+
+public sealed class TestRunSettings
+{
+    public int? Memory { get; init; }
+    public int? Cpu { get; init; }
+}

--- a/Defra.Cdp.Backend.Api/Services/AutoTestRunTriggers/AutoTestRunTriggerEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/AutoTestRunTriggers/AutoTestRunTriggerEventHandler.cs
@@ -1,6 +1,7 @@
 using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Services.Aws.Deployments;
 using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.TestSuites;
 using Defra.Cdp.Backend.Api.Utils.Clients;
 
 namespace Defra.Cdp.Backend.Api.Services.AutoTestRunTriggers;
@@ -8,6 +9,7 @@ namespace Defra.Cdp.Backend.Api.Services.AutoTestRunTriggers;
 public class AutoTestRunTriggerEventHandler(
     IDeploymentsService deploymentsService,
     IAutoTestRunTriggerService autoTestRunTriggerService,
+    ITestRunService testRunService,
     SelfServiceOpsClient selfServiceOpsClient,
     ILogger<AutoTestRunTriggerEventHandler> logger)
 {
@@ -40,8 +42,11 @@ public class AutoTestRunTriggerEventHandler(
                     id,
                     ecsEvent.Detail.DeploymentId, testSuite, deployment.Environment);
 
+                var testRunSettings =
+                    await testRunService.FindTestRunSettings(testSuite, deployment.Environment, cancellationToken);
+
                 await selfServiceOpsClient.TriggerTestSuite(testSuite, deployment.Environment, deployment.User,
-                    cancellationToken);
+                    testRunSettings, cancellationToken);
             }
         }
     }

--- a/Defra.Cdp.Backend.Api/Utils/Clients/SelfServiceOpsClient.cs
+++ b/Defra.Cdp.Backend.Api/Utils/Clients/SelfServiceOpsClient.cs
@@ -20,9 +20,19 @@ public class SelfServiceOpsClient
     }
 
     public async Task TriggerTestSuite(string imageName, string environment, UserDetails? user,
-        CancellationToken cancellationToken)
+        TestRunSettings? testRunSettings, CancellationToken cancellationToken)
     {
-        var body = new { imageName, environment, user };
+        const int defaultCpu = 4096;
+        const int defaultMemory = 8192;
+
+        var body = new
+        {
+            imageName,
+            environment,
+            cpu = testRunSettings?.Cpu ?? defaultCpu,
+            memory = testRunSettings?.Memory ?? defaultMemory,
+            user
+        };
         var payload = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
         var result = await _client.PostAsync(_baseUrl + "/trigger-test-suite", payload, cancellationToken);
         result.EnsureSuccessStatusCode();


### PR DESCRIPTION
Get the latest testRun CPU and Memory in a specific environment and send to Self Service Ops when triggering a test run from a service deployment. Default to previous hardcoded values