### PR TITLE
CORE-571: Make favourite works same as other list pages

### DIFF
--- a/Defra.Cdp.Backend.Api/Models/DeploymentOrMigration.cs
+++ b/Defra.Cdp.Backend.Api/Models/DeploymentOrMigration.cs
@@ -6,5 +6,6 @@ public class DeploymentOrMigration
 {
     public Deployment? Deployment { get; set; }
     public DatabaseMigration? Migration { get; set; }
+    public bool IsFavourite { get; set; }
     public DateTime Created { get; set; }
 }


### PR DESCRIPTION
- Move the favourite work into Mongo query
- Update favourite so all "favourite" Migrations and Deployments are put up front in the results

## Demo

### logged in user with teams
![deployments-and-updates](https://github.com/user-attachments/assets/d23b72a7-70af-440a-be7c-7b5f2aa903b0)

### Logged out user

![deployments-and-updates-logged-out](https://github.com/user-attachments/assets/40969860-53d4-4ece-ac0b-3d640dfeb037)
