### PR TITLE
CORE-1382 update test timeout exit code to be 1

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Resources/ecs/tests/task-stop-timeout-sidecar.json
+++ b/Defra.Cdp.Backend.Api.Tests/Resources/ecs/tests/task-stop-timeout-sidecar.json
@@ -52,7 +52,7 @@
     "containers": [
       {
         "containerArn": "arn:aws:ecs:eu-west-2:120185944470:container/perf-test-ecs-public/16a4e00ec95344cc91fdc6e20cb88896/3bc0dcb9-2064-4851-a9b5-a1a9ef64ec94",
-        "exitCode": 0,
+        "exitCode": 1,
         "lastStatus": "STOPPED",
         "name": "forms-perf-test-timeout",
         "image": "094954420758.dkr.ecr.eu-west-2.amazonaws.com/cdp-timeout-docker:latest",


### PR DESCRIPTION
This relates to changes in the timout sidecar to make the timeout more explicit and to better handle graceful shutdowns