### PR TITLE
adds indexes, removes dupe inserts, better projection

### DIFF
--- a/Defra.Cdp.Backend.Api.IntegrationTests/Services/Deployments/DeploymentServiceTest.cs
+++ b/Defra.Cdp.Backend.Api.IntegrationTests/Services/Deployments/DeploymentServiceTest.cs
@@ -23,7 +23,7 @@ public class DeploymentServiceTest : ServiceTest
 
     public DeploymentServiceTest(MongoContainerFixture fixture) : base(fixture)
     {
-        _mongoFactory = CreateMongoDbClientFactory(); ;
+        _mongoFactory = CreateMongoDbClientFactory();
     }
 
 
@@ -31,16 +31,18 @@ public class DeploymentServiceTest : ServiceTest
     public async Task RegisterDeploymentWithAuditSection()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
-        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
 
-        await repositoryService.Create(new Entity
-        {
-            Name = "test-backend",
-            Teams = [new Team { Name = "test-team", TeamId = "test team" }],
-            Status = Status.Created,
-            Type = Type.Microservice,
-            SubType = SubType.Backend
-        }, TestContext.Current.CancellationToken);
+        await repositoryService.Create(
+            new Entity
+            {
+                Name = "test-backend",
+                Teams = [new Team { Name = "test-team", TeamId = "test team" }],
+                Status = Status.Created,
+                Type = Type.Microservice,
+                SubType = SubType.Backend
+            }, TestContext.Current.CancellationToken);
 
         var deployment = Deployment.FromRequest(new RequestedDeployment
         {
@@ -72,7 +74,8 @@ public class DeploymentServiceTest : ServiceTest
     public async Task RegisterDeploymentWhenAuditDataIsUnavailable()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
-        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
 
         var deployment = Deployment.FromRequest(new RequestedDeployment
         {
@@ -102,7 +105,8 @@ public class DeploymentServiceTest : ServiceTest
     public async Task LinkDeployment()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
-        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
 
         const string lambdaId = "ecs/12345";
         var deployment = Deployment.FromRequest(new RequestedDeployment
@@ -137,7 +141,8 @@ public class DeploymentServiceTest : ServiceTest
     public async Task UpdateDeploymentInstance()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
-        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
 
         const string lambdaId = "ecs/12345";
         var deployment = Deployment.FromRequest(new RequestedDeployment
@@ -175,9 +180,11 @@ public class DeploymentServiceTest : ServiceTest
     public async Task FindWhatsRunningWhereWithNoData()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
-        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
 
-        var result = await service.RunningDeploymentsForService(new DeploymentMatchers(), TestContext.Current.CancellationToken);
+        var result =
+            await service.RunningDeploymentsForService(new DeploymentMatchers(), TestContext.Current.CancellationToken);
 
         Assert.Empty(result);
     }
@@ -187,7 +194,8 @@ public class DeploymentServiceTest : ServiceTest
     public async Task FindWhatsRunningWhereForService()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
-        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
 
         var deployment1 = new Deployment
         {
@@ -199,7 +207,10 @@ public class DeploymentServiceTest : ServiceTest
             Updated = DateTime.Now.AddDays(-1),
             Instances =
             {
-                {"instance-1111", new DeploymentInstanceStatus(DeploymentStatus.Stopped, DateTime.Now.AddDays(-1))}
+                {
+                    "instance-1111",
+                    new DeploymentInstanceStatus(DeploymentStatus.Stopped, DateTime.Now.AddDays(-1))
+                }
             },
             Status = DeploymentStatus.Stopped
         };
@@ -213,7 +224,7 @@ public class DeploymentServiceTest : ServiceTest
             Updated = DateTime.Now,
             Instances =
             {
-                {"instance-2222", new DeploymentInstanceStatus(DeploymentStatus.Stopped, DateTime.Now)}
+                { "instance-2222", new DeploymentInstanceStatus(DeploymentStatus.Stopped, DateTime.Now) }
             },
             Status = DeploymentStatus.Running
         };
@@ -221,7 +232,8 @@ public class DeploymentServiceTest : ServiceTest
         await service.RegisterDeployment(deployment1, TestContext.Current.CancellationToken);
         await service.RegisterDeployment(deployment2, TestContext.Current.CancellationToken);
 
-        var result = await service.RunningDeploymentsForService(deployment1.Service, TestContext.Current.CancellationToken);
+        var result =
+            await service.RunningDeploymentsForService(deployment1.Service, TestContext.Current.CancellationToken);
         // The most recent running service should be shown
         Assert.Single(result);
         Assert.Equal(deployment2.CdpDeploymentId, result[0].CdpDeploymentId);
@@ -231,7 +243,8 @@ public class DeploymentServiceTest : ServiceTest
     public async Task CleansUpStuckRequestsOnRegister()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
-        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
 
         var stuckDeployment = new Deployment
         {
@@ -283,7 +296,8 @@ public class DeploymentServiceTest : ServiceTest
         Assert.Null(result.Audit?.User);
 
         // Check its removed the old requested deployment
-        var stuck = await service.FindDeployment(stuckDeployment.CdpDeploymentId, TestContext.Current.CancellationToken);
+        var stuck = await service.FindDeployment(stuckDeployment.CdpDeploymentId,
+            TestContext.Current.CancellationToken);
         Assert.Equal(DeploymentStatus.Failed, stuck?.Status);
     }
 
@@ -291,7 +305,8 @@ public class DeploymentServiceTest : ServiceTest
     public async Task FindDeployments()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
-        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
         var ct = TestContext.Current.CancellationToken;
         await DeploymentsTestHelpers.PopulateWithTestData(service, ct);
 
@@ -330,7 +345,8 @@ public class DeploymentServiceTest : ServiceTest
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
         var service =
-            new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient, new NullLoggerFactory());
+            new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+                new NullLoggerFactory());
         var ct = TestContext.Current.CancellationToken;
         var deployments = await DeploymentsTestHelpers.PopulateWithTestData(service, ct);
 
@@ -342,7 +358,7 @@ public class DeploymentServiceTest : ServiceTest
         Assert.Equivalent(services, filters.Services);
         Assert.Equivalent(users, filters.Users);
     }
-
+    
     [Fact]
     public async Task GetWhatsRunningWhereFilters()
     {

--- a/Defra.Cdp.Backend.Api.IntegrationTests/Services/Entities/EntitiesServiceTest.cs
+++ b/Defra.Cdp.Backend.Api.IntegrationTests/Services/Entities/EntitiesServiceTest.cs
@@ -39,7 +39,29 @@ public class EntitiesServiceTest(MongoContainerFixture fixture) : MongoTestSuppo
         Assert.Equivalent(untaggedEntity?.Tags, new List<string> { "PRR" });
 
     }
+    
+        
+    [Fact]
+    public async Task GetEntityIds_only_returns_entity_ids()
+    {
+        var mongoFactory = CreateMongoDbClientFactory();
+        var service = new EntitiesService(mongoFactory, new NullLoggerFactory());
 
+        var entity = new Entity
+        {
+            Name = _fooRepository.Id,
+            Teams = [],
+            Status = Status.Created,
+            Type = Type.Microservice
+        };
+        
+        await service.Create(entity, TestContext.Current.CancellationToken);
+        var result = await service.GetEntityIds(new EntityMatcher(), TestContext.Current.CancellationToken);
+        Assert.NotNull(result);
+        Assert.Equal([_fooRepository.Id], result);
+    }
+
+    
     private readonly Repository _fooRepository = new()
     {
         Id = "foo",

--- a/Defra.Cdp.Backend.Api/Endpoints/DeploymentsEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/DeploymentsEndpoint.cs
@@ -6,6 +6,7 @@ using Defra.Cdp.Backend.Api.Services.Github.ScheduledTasks;
 using Defra.Cdp.Backend.Api.Services.Secrets;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using static Defra.Cdp.Backend.Api.Services.Aws.Deployments.DeploymentStatus;
 
 namespace Defra.Cdp.Backend.Api.Endpoints;
 
@@ -41,7 +42,7 @@ public static class DeploymentsEndpoint
         string[]? servicesForTeam = null;
         if (teamIds.Length > 0)
         {
-            servicesForTeam = (await entitiesService.GetEntities( new EntityMatcher {TeamIds = teamIds }, cancellationToken)).Select(r => r.Name).ToArray();
+            servicesForTeam = (await entitiesService.GetEntityIds( new EntityMatcher {TeamIds = teamIds }, cancellationToken)).ToArray();
         }
 
         var query = matchers with { Services = servicesForTeam };
@@ -73,7 +74,7 @@ public static class DeploymentsEndpoint
         string[]? servicesForTeam = null;
         if (teamIds.Length > 0)
         {
-            servicesForTeam = (await entitiesService.GetEntities( new EntityMatcher {TeamIds = teamIds }, cancellationToken)).Select(r => r.Name).ToArray();
+            servicesForTeam = (await entitiesService.GetEntityIds( new EntityMatcher {TeamIds = teamIds }, cancellationToken)).ToArray();
         }
 
         var query = matchers with { Services = servicesForTeam };
@@ -132,7 +133,7 @@ public static class DeploymentsEndpoint
         string[]? servicesForTeam = null;
         if (teamIds.Length > 0)
         {
-            servicesForTeam = (await entitiesService.GetEntities( new EntityMatcher {TeamIds = teamIds }, cancellationToken)).Select(r => r.Name).ToArray();
+            servicesForTeam = (await entitiesService.GetEntityIds( new EntityMatcher {TeamIds = teamIds }, cancellationToken)).ToArray();
         }
 
         var deployments = await deploymentsService.RunningDeploymentsForService(

--- a/Defra.Cdp.Backend.Api/Endpoints/EntitiesEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/EntitiesEndpoint.cs
@@ -33,7 +33,7 @@ public static class EntitiesEndpoint
         app.MapPatch("/entities/{name}/schedules/{scheduleId}", UpdateSchedule);
         app.MapDelete("/entities/{name}/schedules/{scheduleId}", DeleteSchedule);
         app.MapGet("/entities/{name}/resources", GetEntityResources);
-        app.MapPost("/entities/{name}/resources", CreateS3ResourceForEntity);
+        app.MapPost("/entities/{name}/resources", CreateResourceForEntity);
         app.MapGet("/entities/{name}/resources/{environment}", GetEntityResourcesForEnv);
         app.MapGet("/entities/{name}/topology/{environment}", GetEntityTopologyForEnv);
     }
@@ -304,7 +304,7 @@ public static class EntitiesEndpoint
         return TypedResults.Ok(environments);
     }
     
-    private static async Task<Results<BadRequest<ApiError>, Ok<GitHubTriggerWorkflowResponse>>> CreateS3ResourceForEntity(
+    private static async Task<Results<BadRequest<ApiError>, Ok<GitHubTriggerWorkflowResponse>>> CreateResourceForEntity(
         [FromRoute] string name,
         [FromBody] CreateResourceRequest request,
         [FromServices] ICreateResourceService createResourceService,

--- a/Defra.Cdp.Backend.Api/Endpoints/EntitiesEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/EntitiesEndpoint.cs
@@ -304,7 +304,7 @@ public static class EntitiesEndpoint
         return TypedResults.Ok(environments);
     }
     
-    private static async Task<Results<BadRequest<ApiError>, Ok<GitHubTriggerWorkflowResponse>>> CreateResourceForEntity(
+    private static async Task<Results<NotFound, BadRequest<ApiError>, Ok<GitHubTriggerWorkflowResponse>>> CreateResourceForEntity(
         [FromRoute] string name,
         [FromBody] CreateResourceRequest request,
         [FromServices] ICreateResourceService createResourceService,
@@ -315,6 +315,10 @@ public static class EntitiesEndpoint
         {
             try
             {
+                if (await entitiesService.GetEntity(s3.Service, cancellationToken)== null)
+                {
+                    return TypedResults.NotFound();
+                }
                 var response = await createResourceService.TriggerWorkflow(s3.ToWorkflowInputs(), cancellationToken);
                 return TypedResults.Ok(response);
             }

--- a/Defra.Cdp.Backend.Api/Services/Deployments/DeploymentsService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Deployments/DeploymentsService.cs
@@ -91,8 +91,9 @@ public class DeploymentsService(
             builder.Descending(d => d.Service),
             builder.Descending(d => d.Version)
         ));
+        var service = new CreateIndexModel<Deployment>(builder.Ascending(d => d.Service));
 
-        return [created, updated, lambdaId, cdpDeploymentId, envServiceVersion];
+        return [created, updated, lambdaId, cdpDeploymentId, envServiceVersion, service];
     }
 
     public async Task RegisterDeployment(Deployment deployment, CancellationToken ct)
@@ -286,11 +287,9 @@ public class DeploymentsService(
 
         if (query.Favourites?.Length > 0)
         {
-            var entities = await entitiesService.GetEntities(
+            var servicesOwnedByTeam = await entitiesService.GetEntityIds(
                 new EntityMatcher { Types = [Type.Microservice], Statuses = [Status.Created], TeamIds = query.Favourites },
-                new EntitySearchOptions { Summary = true },
                 ct);
-            var servicesOwnedByTeam = entities.Select(r => r.Name);
             deployments = deployments.OrderByDescending(d => servicesOwnedByTeam.Contains(d.Service)).ToList();
         }
 
@@ -343,13 +342,11 @@ public class DeploymentsService(
         //  we may be able to do this in an easier way in the UI
         if (query.Favourites?.Length > 0)
         {
-            var entities = await entitiesService.GetEntities(
+            var servicesOwnedByTeam = await entitiesService.GetEntityIds(
                 new EntityMatcher { Types = [Type.Microservice], Statuses = [Status.Created], TeamIds = query.Favourites },
-                new EntitySearchOptions { Summary = true },
                 ct);
-            var servicesOwnedByTeam = entities.Select(r => r.Name);
             deployments = deployments.OrderByDescending(d =>
-                servicesOwnedByTeam.Contains(d.Deployment?.Service ?? d.Migration?.Service)
+                servicesOwnedByTeam.Contains((d.Deployment?.Service ?? d.Migration?.Service)!)
             ).ToList();
         }
 
@@ -454,9 +451,7 @@ public class DeploymentsService(
             .Distinct(d => d.Service, filter, cancellationToken: ct)
             .ToListAsync(ct);
 
-        var statuses = await Collection
-            .Distinct(d => d.Status, filter, cancellationToken: ct)
-            .ToListAsync(ct);
+        List<string> statuses = [Running, Pending, Undeployed];
 
         var users = await UserDetailsList(ct);
 

--- a/Defra.Cdp.Backend.Api/Services/Entities/EntitiesService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Entities/EntitiesService.cs
@@ -15,6 +15,7 @@ namespace Defra.Cdp.Backend.Api.Services.Entities;
 public interface IEntitiesService
 {
     Task<Entity?> GetEntity(string entityName, CancellationToken cancellationToken);
+    Task<List<string>> GetEntityIds(EntityMatcher matcher, CancellationToken cancellationToken);
     Task<List<Entity>> GetEntities(EntityMatcher matcher, CancellationToken cancellationToken); //Used for tests
 
     Task<List<Entity>> GetEntities(EntityMatcher matcher, EntitySearchOptions options,
@@ -76,6 +77,21 @@ public class EntitiesService(
         return entity;
     }
 
+    /// <summary>
+    /// Returns a list of all entities ids/names that match the matcher with default options.
+    /// </summary>
+    /// <param name="matcher"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task<List<string>> GetEntityIds(EntityMatcher matcher, CancellationToken cancellationToken)
+    {
+        return await Collection
+            .Find(matcher.Match())
+            .Sort(Builders<Entity>.Sort.Ascending(e => e.Name))
+            .Project(e => e.Name)
+            .ToListAsync(cancellationToken);
+    }
+    
     /// <summary>
     /// Returns a list of all entities that match the matcher with default options.
     /// </summary>

--- a/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
@@ -86,11 +86,7 @@ public class SecretEventHandler(
             await secretsService.DeleteSecrets(secretsToDelete, cancellationToken);
         }
 
-        if (secrets.Count != 0)
-        {
-            await secretsService.UpdateSecrets(secrets, cancellationToken);
-        }
-        
+        await secretsService.UpdateSecrets(secrets, cancellationToken);
         logger.LogInformation("Get All Secrets: Updated secrets for {Environment}", body.Environment);
     }
 

--- a/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/SecretEventHandler.cs
@@ -90,8 +90,7 @@ public class SecretEventHandler(
         {
             await secretsService.UpdateSecrets(secrets, cancellationToken);
         }
-
-        await secretsService.UpdateSecrets(secrets, cancellationToken);
+        
         logger.LogInformation("Get All Secrets: Updated secrets for {Environment}", body.Environment);
     }
 

--- a/Defra.Cdp.Backend.Api/Services/Secrets/SecretsService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Secrets/SecretsService.cs
@@ -123,11 +123,11 @@ public class SecretsService(IMongoDbClientFactory connectionFactory, ILoggerFact
     protected override List<CreateIndexModel<TenantSecrets>> DefineIndexes(
         IndexKeysDefinitionBuilder<TenantSecrets> builder)
     {
-        var serviceAndEnv = new CreateIndexModel<TenantSecrets>(builder.Combine(
+        var serviceAndEnvIndex = new CreateIndexModel<TenantSecrets>(builder.Combine(
             builder.Ascending(s => s.Service),
             builder.Ascending(s => s.Environment)
         ));
-
-        return [serviceAndEnv];
+        var envIndex = new CreateIndexModel<TenantSecrets>(builder.Ascending(s => s.Environment));
+        return [serviceAndEnvIndex, envIndex];
     }
 }


### PR DESCRIPTION
The slow running query logs highlighted a couple of queries that were unindexed. 
Also there's quite a few instances of entities being queried only to throw away all of the data except for the id. Given the size of the entity object this is probably pulling far more data out of the db than it has to. I've added a new method to entity service `getEntityIds` which projects just the entity id

