### PR TITLE
CORE-2185: Fix entity search combining name and teamIds filters

### DIFF
--- a/Defra.Cdp.Backend.Api.IntegrationTests/Services/Entities/EntitiesServiceTest.cs
+++ b/Defra.Cdp.Backend.Api.IntegrationTests/Services/Entities/EntitiesServiceTest.cs
@@ -62,6 +62,38 @@ public class EntitiesServiceTest(MongoContainerFixture fixture) : MongoTestSuppo
     }
 
     
+    [Fact]
+    public async Task GetEntities_FiltersPartialNameAndTeamIdsTogether()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var service = new EntitiesService(CreateMongoDbClientFactory(), new NullLoggerFactory());
+
+        var platformService = new Entity
+        {
+            Name = "tenant-platform-service",
+            Teams = [new Team { TeamId = "platform", Name = "Platform" }],
+            Status = Status.Created,
+            Type = Type.Microservice
+        };
+
+        var otherTeamService = new Entity
+        {
+            Name = "tenant-other-service",
+            Teams = [new Team { TeamId = "other-team", Name = "Other Team" }],
+            Status = Status.Created,
+            Type = Type.Microservice
+        };
+
+        await service.Create(platformService, ct);
+        await service.Create(otherTeamService, ct);
+
+        var matcher = new EntityMatcher(PartialName: "tenant", TeamIds: ["platform"]);
+        var results = await service.GetEntities(matcher, ct);
+
+        Assert.Single(results);
+        Assert.Equal("tenant-platform-service", results[0].Name);
+    }
+
     private readonly Repository _fooRepository = new()
     {
         Id = "foo",

--- a/Defra.Cdp.Backend.Api/Services/Entities/EntityMatcher.cs
+++ b/Defra.Cdp.Backend.Api/Services/Entities/EntityMatcher.cs
@@ -30,8 +30,8 @@ public record EntityMatcher(
         {
             filter &= builder.Regex(t => t.Name, new BsonRegularExpression(PartialName, "i"));
         }
-        
-        else if (TeamIds is { Length: > 0 })
+
+        if (TeamIds is { Length: > 0 })
         {
             filter &= builder.AnyIn(new StringFieldDefinition<Entity>("teams.teamId"), TeamIds);
         }


### PR DESCRIPTION
- TeamIds filter in EntityMatcher was in an `else if` block, causing it  to be ignored whenever a Name or PartialName filter was also present
- Searching by service name on "My Services" tab was returning services  from other teams
- Changed `else if` to `if` so both filters are always applied together