### PR TITLE
CORE-3384: Add deployment notifications for services

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/DeploymentStateChangeEventHandlerTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/DeploymentStateChangeEventHandlerTests.cs
@@ -1,0 +1,156 @@
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.Aws.Deployments;
+using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.Notifications;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Aws.Deployments;
+
+public class DeploymentStateChangeEventHandlerTests
+{
+    private readonly EcsDeploymentStateChangeEvent _deploymentFailedEvent = new(
+        "ECS Deployment State Change",
+        "111111111111",
+        new EcsDeploymentStateChangeDetail(
+            "ERROR",
+            DeploymentStatus.SERVICE_DEPLOYMENT_FAILED,
+            "ecs-svc/123",
+            DateTime.UtcNow,
+            "service deployment failed"
+        )
+    );
+
+    [Fact]
+    public async Task DispatchesFailureNotificationWhenDeploymentFails()
+    {
+        var deploymentsService = Substitute.For<IDeploymentsService>();
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var statusChange = StatusChange(
+            oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_IN_PROGRESS,
+            newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED);
+
+        deploymentsService
+            .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_FAILED, "service deployment failed", Arg.Any<CancellationToken>())
+            .Returns(statusChange);
+
+        var handler = Handler(deploymentsService, notificationDispatcher);
+
+        await handler.Handle("message-1", _deploymentFailedEvent, TestContext.Current.CancellationToken);
+
+        await deploymentsService.Received().UpdateDeploymentStatus(
+            "ecs-svc/123",
+            DeploymentStatus.SERVICE_DEPLOYMENT_FAILED,
+            "service deployment failed",
+            Arg.Any<CancellationToken>());
+        await notificationDispatcher.Received().Dispatch(
+            Arg.Is<DeploymentFailedEvent>(e =>
+                e.DeploymentId == statusChange.DeploymentId &&
+                e.Entity == statusChange.EntityId &&
+                e.Environment == statusChange.Environment &&
+                e.Version == statusChange.Version &&
+                e.UserDisplayName == statusChange.UserDisplayName),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DispatchesSuccessNotificationWhenDeploymentCompletes()
+    {
+        var deploymentsService = Substitute.For<IDeploymentsService>();
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var statusChange = StatusChange(
+            oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_IN_PROGRESS,
+            newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED);
+        var completedEvent = _deploymentFailedEvent with
+        {
+            Detail = _deploymentFailedEvent.Detail with
+            {
+                EventType = "INFO",
+                EventName = DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                Reason = "service deployment completed"
+            }
+        };
+
+        deploymentsService
+            .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED, "service deployment completed", Arg.Any<CancellationToken>())
+            .Returns(statusChange);
+
+        var handler = Handler(deploymentsService, notificationDispatcher);
+
+        await handler.Handle("message-1", completedEvent, TestContext.Current.CancellationToken);
+
+        await notificationDispatcher.Received().Dispatch(
+            Arg.Is<DeploymentSuccessEvent>(e =>
+                e.DeploymentId == statusChange.DeploymentId &&
+                e.Entity == statusChange.EntityId &&
+                e.Environment == statusChange.Environment &&
+                e.Version == statusChange.Version &&
+                e.UserDisplayName == statusChange.UserDisplayName),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotDispatchNotificationWhenDeploymentStatusHasNotChanged()
+    {
+        var deploymentsService = Substitute.For<IDeploymentsService>();
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+
+        deploymentsService
+            .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_FAILED, "service deployment failed", Arg.Any<CancellationToken>())
+            .Returns(StatusChange(
+                oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED,
+                newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED));
+
+        var handler = Handler(deploymentsService, notificationDispatcher);
+
+        await handler.Handle("message-1", _deploymentFailedEvent, TestContext.Current.CancellationToken);
+
+        await notificationDispatcher.DidNotReceive().Dispatch(
+            Arg.Any<INotificationEvent>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotDispatchNotificationWhenDeploymentStatusIsNotFound()
+    {
+        var deploymentsService = Substitute.For<IDeploymentsService>();
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+
+        deploymentsService
+            .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_FAILED, "service deployment failed", Arg.Any<CancellationToken>())
+            .ReturnsNull();
+
+        var handler = Handler(deploymentsService, notificationDispatcher);
+
+        await handler.Handle("message-1", _deploymentFailedEvent, TestContext.Current.CancellationToken);
+
+        await notificationDispatcher.DidNotReceive().Dispatch(
+            Arg.Any<INotificationEvent>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static DeploymentStateChangeEventHandler Handler(
+        IDeploymentsService deploymentsService,
+        INotificationDispatcher notificationDispatcher)
+    {
+        return new DeploymentStateChangeEventHandler(
+            deploymentsService,
+            notificationDispatcher,
+            NullLogger<DeploymentStateChangeEventHandler>.Instance);
+    }
+
+    private static ServiceStatusChange StatusChange(string? oldStatus, string newStatus)
+    {
+        return new ServiceStatusChange
+        {
+            DeploymentId = "ecs-svc/123",
+            Environment = "dev",
+            OldStatus = oldStatus,
+            NewStatus = newStatus,
+            EntityId = "cdp-portal-backend",
+            Version = "1.2.3",
+            UserDisplayName = "A User"
+        };
+    }
+}

--- a/Defra.Cdp.Backend.Api.Tests/Services/Notifications/NotificationOptionsLookupTest.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Notifications/NotificationOptionsLookupTest.cs
@@ -8,7 +8,6 @@ namespace Defra.Cdp.Backend.Api.Tests.Services.Notifications;
 
 public class NotificationOptionsLookupTest
 {
-   
     [Fact]
     public void It_returns_correct_options_for_journey_tests()
     {
@@ -20,26 +19,19 @@ public class NotificationOptionsLookupTest
             { Test, new CdpTenant() },
             { Management, new CdpTenant() }
         };
-        
-        var entity = new Entity { Name = "backend-tests", Type = Type.TestSuite, SubType = SubType.Journey, Environments = envs };
+
+        var entity = new Entity
+        {
+            Name = "backend-tests", Type = Type.TestSuite, SubType = SubType.Journey, Environments = envs
+        };
 
         var options = NotificationOptionLookup.FindOptionsForEntity(entity);
 
-        Assert.Contains(options,
-            n => n is
-            {
-                EventType: NotificationTypes.TestFailed,
-                Environments: [Prod, PerfTest, Dev, Test, Management]
-            });
-        
-        Assert.Contains(options,
-            n => n is
-            {
-                EventType: NotificationTypes.TestPassed,
-                Environments: [Prod, PerfTest, Dev, Test, Management]
-            });
+        Assert.Collection(options,
+            option => AssertOption(option, NotificationTypes.TestFailed, Prod, PerfTest, Dev, Test, Management),
+            option => AssertOption(option, NotificationTypes.TestPassed, Prod, PerfTest, Dev, Test, Management));
     }
-    
+
     [Fact]
     public void It_returns_correct_options_for_perf_tests()
     {
@@ -52,22 +44,18 @@ public class NotificationOptionsLookupTest
             { Management, new CdpTenant() }
         };
 
-        var envNames = envs.Keys.ToList();
-        
-        var entity = new Entity { Name = "backend-tests", Type = Type.TestSuite, SubType = SubType.Performance, Environments = envs };
+        var entity = new Entity
+        {
+            Name = "backend-tests", Type = Type.TestSuite, SubType = SubType.Performance, Environments = envs
+        };
 
         var options = NotificationOptionLookup.FindOptionsForEntity(entity);
 
-        Assert.Contains(options,
-            n => n is
-            {
-                EventType: NotificationTypes.TestFailed,
-                Environments: [PerfTest]
-            });
-        Assert.Contains(options, n => n is { EventType: NotificationTypes.TestPassed, Environments: [PerfTest] });
+        Assert.Collection(options,
+            option => AssertOption(option, NotificationTypes.TestFailed, PerfTest),
+            option => AssertOption(option, NotificationTypes.TestPassed, PerfTest));
     }
 
-    
     [Fact]
     public void It_returns_correct_options_for_microservice()
     {
@@ -79,16 +67,22 @@ public class NotificationOptionsLookupTest
             { Test, new CdpTenant() },
             { Management, new CdpTenant() }
         };
-        
-        var entity = new Entity { Name = "backend-service", Type = Type.Microservice, SubType = SubType.Backend, Environments = envs };
+
+        var entity = new Entity
+        {
+            Name = "backend-service", Type = Type.Microservice, SubType = SubType.Backend, Environments = envs
+        };
 
         var options = NotificationOptionLookup.FindOptionsForEntity(entity);
 
-        Assert.Contains(options,
-            n => n is
-            {
-                EventType: NotificationTypes.DeploymentFailed,
-                Environments: [Prod, PerfTest, Dev, Test, Management]
-            });
+        Assert.Collection(options,
+            option => AssertOption(option, NotificationTypes.DeploymentFailed, Prod, PerfTest, Dev, Test, Management),
+            option => AssertOption(option, NotificationTypes.DeploymentSuccess, Prod, PerfTest, Dev, Test, Management));
+    }
+
+    private static void AssertOption(NotificationOptions option, string eventType, params string[] environments)
+    {
+        Assert.Equal(eventType, option.EventType);
+        Assert.Equal(environments, option.Environments);
     }
 }

--- a/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
@@ -13,34 +13,32 @@ public class DeploymentStateChangeEventHandler(
     {
         logger.LogInformation("{Id} Handling EcsDeploymentStateChange Update {DeploymentId}, {Name} {Reason}", id, ecsEvent.Detail.DeploymentId, ecsEvent.Detail.EventName, ecsEvent.Detail.Reason);
         var statusChange = await deploymentsService.UpdateDeploymentStatus(ecsEvent.Detail.DeploymentId, ecsEvent.Detail.EventName, ecsEvent.Detail.Reason, cancellationToken);
-        await TriggerDeploymentNotification(statusChange, cancellationToken);
+        await TriggerDeploymentNotificationOnTransition(statusChange, cancellationToken);
     }
 
-    private async Task TriggerDeploymentNotification(ServiceStatusChange? statusChange, CancellationToken cancellationToken)
+    private async Task TriggerDeploymentNotificationOnTransition(ServiceStatusChange? statusChange, CancellationToken cancellationToken)
     {
-        // Only trigger on an actual status transition, not repeated updates with the same status
-        INotificationEvent? notificationEvent = statusChange switch
+        if (statusChange is null || statusChange.NewStatus == statusChange.OldStatus)
+            return;
+
+        INotificationEvent? notificationEvent = statusChange.NewStatus switch
         {
-            { NewStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED, OldStatus: var old }
-                when old != DeploymentStatus.SERVICE_DEPLOYMENT_FAILED
-                => new DeploymentFailedEvent
-                {
-                    DeploymentId = statusChange.DeploymentId,
-                    Entity = statusChange.EntityId,
-                    Environment = statusChange.Environment,
-                    Version = statusChange.Version,
-                    UserDisplayName = statusChange.UserDisplayName
-                },
-            { NewStatus: DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED, OldStatus: var old }
-                when old != DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED
-                => new DeploymentSuccessEvent
-                {
-                    DeploymentId = statusChange.DeploymentId,
-                    Entity = statusChange.EntityId,
-                    Environment = statusChange.Environment,
-                    Version = statusChange.Version,
-                    UserDisplayName = statusChange.UserDisplayName
-                },
+            DeploymentStatus.SERVICE_DEPLOYMENT_FAILED => new DeploymentFailedEvent
+            {
+                DeploymentId = statusChange.DeploymentId,
+                Entity = statusChange.EntityId,
+                Environment = statusChange.Environment,
+                Version = statusChange.Version,
+                UserDisplayName = statusChange.UserDisplayName
+            },
+            DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED => new DeploymentSuccessEvent
+            {
+                DeploymentId = statusChange.DeploymentId,
+                Entity = statusChange.EntityId,
+                Environment = statusChange.Environment,
+                Version = statusChange.Version,
+                UserDisplayName = statusChange.UserDisplayName
+            },
             _ => null
         };
 

--- a/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
@@ -11,24 +11,40 @@ public class DeploymentStateChangeEventHandler(
 {
     public async Task Handle(string id, EcsDeploymentStateChangeEvent ecsEvent, CancellationToken cancellationToken)
     {
-        logger.LogInformation("{id} Handling EcsDeploymentStateChange Update {deploymentId}, {name} {reason}", id, ecsEvent.Detail.DeploymentId, ecsEvent.Detail.EventName, ecsEvent.Detail.Reason);
+        logger.LogInformation("{Id} Handling EcsDeploymentStateChange Update {DeploymentId}, {Name} {Reason}", id, ecsEvent.Detail.DeploymentId, ecsEvent.Detail.EventName, ecsEvent.Detail.Reason);
         var statusChange = await deploymentsService.UpdateDeploymentStatus(ecsEvent.Detail.DeploymentId, ecsEvent.Detail.EventName, ecsEvent.Detail.Reason, cancellationToken);
         await TriggerDeploymentNotification(statusChange, cancellationToken);
     }
 
     private async Task TriggerDeploymentNotification(ServiceStatusChange? statusChange, CancellationToken cancellationToken)
     {
-        // Ensure we only trigger the alert on the status change, no subsequent failure updates
-        if (statusChange is { NewStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED } && statusChange.OldStatus != statusChange.NewStatus)
+        // Only trigger on an actual status transition, not repeated updates with the same status
+        INotificationEvent? notificationEvent = statusChange switch
         {
-            var failureEvent = new DeploymentFailedEvent
-            {
-                DeploymentId = statusChange.DeploymentId,
-                Entity = statusChange.EntityId,
-                Environment = statusChange.Environment,
-                Version = statusChange.Version
-            };
-            await notificationDispatcher.Dispatch(failureEvent, cancellationToken);
-        }
+            { NewStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED, OldStatus: var old }
+                when old != DeploymentStatus.SERVICE_DEPLOYMENT_FAILED
+                => new DeploymentFailedEvent
+                {
+                    DeploymentId = statusChange.DeploymentId,
+                    Entity = statusChange.EntityId,
+                    Environment = statusChange.Environment,
+                    Version = statusChange.Version,
+                    UserDisplayName = statusChange.UserDisplayName
+                },
+            { NewStatus: DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED, OldStatus: var old }
+                when old != DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED
+                => new DeploymentSuccessEvent
+                {
+                    DeploymentId = statusChange.DeploymentId,
+                    Entity = statusChange.EntityId,
+                    Environment = statusChange.Environment,
+                    Version = statusChange.Version,
+                    UserDisplayName = statusChange.UserDisplayName
+                },
+            _ => null
+        };
+
+        if (notificationEvent != null)
+            await notificationDispatcher.Dispatch(notificationEvent, cancellationToken);
     }
 }

--- a/Defra.Cdp.Backend.Api/Services/Deployments/DeploymentsService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Deployments/DeploymentsService.cs
@@ -23,6 +23,7 @@ public record ServiceStatusChange
     public required string NewStatus { get; init; }
     public required string EntityId { get; init; }
     public required string Version { get; init; }
+    public string? UserDisplayName { get; init; }
 }
 
 public interface IDeploymentsService
@@ -208,6 +209,7 @@ public class DeploymentsService(
             Environment = deployment.Environment,
             EntityId = deployment.Service,
             Version = deployment.Version,
+            UserDisplayName = deployment.User?.DisplayName,
             NewStatus = deployment.LastDeploymentStatus,
             OldStatus = oldStatus
         };

--- a/Defra.Cdp.Backend.Api/Services/Notifications/NotificationEvents.cs
+++ b/Defra.Cdp.Backend.Api/Services/Notifications/NotificationEvents.cs
@@ -8,8 +8,9 @@ public static class NotificationTypes
     public const string TestFailed = "testfailed";
     public const string TestPassed = "testpassed";
     public const string DeploymentFailed = "deploymentfailed";
+    public const string DeploymentSuccess = "deploymentsuccess";
 
-    public static readonly string[] All = [TestPassed, TestFailed, DeploymentFailed];
+    public static readonly string[] All = [TestPassed, TestFailed, DeploymentFailed, DeploymentSuccess];
 }
 
 public interface INotificationEvent 
@@ -56,9 +57,25 @@ public class DeploymentFailedEvent : INotificationEvent
     public required string? Environment { get; init; }
     public required string Version { get; init; }
     public required string DeploymentId { get; init; }
+    public string? UserDisplayName { get; init; }
 
     public SlackMessageBody SlackMessage()
     {
         return SlackMessageTemplates.DeploymentFailedTemplate(this);
+    }
+}
+
+public class DeploymentSuccessEvent : INotificationEvent
+{
+    public string EventType => NotificationTypes.DeploymentSuccess;
+    public required string Entity { get; init; }
+    public required string? Environment { get; init; }
+    public required string Version { get; init; }
+    public required string DeploymentId { get; init; }
+    public string? UserDisplayName { get; init; }
+
+    public SlackMessageBody SlackMessage()
+    {
+        return SlackMessageTemplates.DeploymentSuccessTemplate(this);
     }
 }

--- a/Defra.Cdp.Backend.Api/Services/Notifications/NotificationOptions.cs
+++ b/Defra.Cdp.Backend.Api/Services/Notifications/NotificationOptions.cs
@@ -29,6 +29,11 @@ public static class NotificationOptionLookup
                     EventType = NotificationTypes.DeploymentFailed,
                     Environments = entity.Environments.Keys.ToList()
                 });
+                options.Add(new NotificationOptions
+                {
+                    EventType = NotificationTypes.DeploymentSuccess,
+                    Environments = entity.Environments.Keys.ToList()
+                });
             
                 // Shuttering
                 // Todo: When we add shuttering, loop though the envs and check if they have any shutter-able urls.

--- a/Defra.Cdp.Backend.Api/Services/Notifications/Slack/Templates/DeploymentSuccessTemplate.cs
+++ b/Defra.Cdp.Backend.Api/Services/Notifications/Slack/Templates/DeploymentSuccessTemplate.cs
@@ -4,10 +4,10 @@ namespace Defra.Cdp.Backend.Api.Services.Notifications.Slack.Templates;
 
 public static partial class SlackMessageTemplates
 {
-    public static SlackMessageBody DeploymentFailedTemplate(DeploymentFailedEvent e)
+    public static SlackMessageBody DeploymentSuccessTemplate(DeploymentSuccessEvent e)
     {
         var deploymentUri = new UriBuilder(PortalPublicUrl.BaseUri()) { Path = $"/deployments/{e.Environment}/{e.DeploymentId}" };
-        
+
         return new SlackMessageBody
         {
             Blocks =
@@ -15,7 +15,7 @@ public static partial class SlackMessageTemplates
                 new Block
                 {
                     Type = "header",
-                    Text = new TextObject { Type = "plain_text", Text = $"❌ {e.Entity}:{e.Version} Deployment failed", Emoji = true }
+                    Text = new TextObject { Type = "plain_text", Text = $"✅ {e.Entity}:{e.Version} Deployment succeeded", Emoji = true }
                 },
                 new Block
                 {


### PR DESCRIPTION
- Add deployment success notification alongside existing deployment failure notification
- Dispatch notifications only on actual status transitions, not repeated updates with the same status
- Add DeploymentStateChangeEventHandler tests covering success, failure, and no-op scenarios
- Tighten NotificationOptionsLookupTest assertions from Contains to Collection