### PR TITLE
CORE-3424: Add scheduled DeployService task for nightly canary deployments

### DIFF
--- a/Defra.Cdp.Backend.Api.IntegrationTests/Endpoints/SchedulesEndpointTestSupport.cs
+++ b/Defra.Cdp.Backend.Api.IntegrationTests/Endpoints/SchedulesEndpointTestSupport.cs
@@ -87,6 +87,39 @@ public class SchedulesEndpointTestSupport : MongoTestSupport
             $"Expected 201 Created but got {response.StatusCode}. json: {body}");
     }
 
+    [Fact]
+    public async Task Should_create_deploy_service_task_schedule()
+    {
+        var client = _host.GetTestClient();
+
+        var json = """
+                   {
+                     "task": {
+                       "type": "DeployService",
+                       "entityId": "my-microservice-entity",
+                       "environments": ["infra-dev", "prod"]
+                     },
+                     "config": {
+                       "frequency": "DAILY",
+                       "time": "02:15"
+                     }
+                   }
+                   """;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/schedules")
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", MockToken);
+
+        var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(response.StatusCode == HttpStatusCode.Created,
+            $"Expected 201 Created but got {response.StatusCode}. json: {body}");
+    }
+
     private static Entity[] EntityTestData()
     {
         return
@@ -100,6 +133,16 @@ public class SchedulesEndpointTestSupport : MongoTestSupport
                 ],
                 Status = Status.Created,
                 Type = Type.TestSuite
+            },
+            new Entity
+            {
+                Name = "my-microservice-entity",
+                Teams =
+                [
+                    new Team { Name = "Platform", TeamId = "platform" }, new Team { Name = "Tenant", TeamId = "tenant" }
+                ],
+                Status = Status.Created,
+                Type = Type.Microservice
             }
         ];
     }

--- a/Defra.Cdp.Backend.Api.Tests/Services/Deployments/ServiceDeploymentExecutorTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Deployments/ServiceDeploymentExecutorTests.cs
@@ -1,0 +1,97 @@
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.GithubWorkflowEvents.Services;
+using Defra.Cdp.Backend.Api.Utils.Clients;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Deployments;
+
+public class ServiceDeploymentExecutorTests
+{
+    private readonly IDeploymentsService _deploymentsService = Substitute.For<IDeploymentsService>();
+    private readonly ISelfServiceOpsClient _selfServiceOpsClient = Substitute.For<ISelfServiceOpsClient>();
+    private readonly IAppConfigVersionsService _appConfigVersionsService = Substitute.For<IAppConfigVersionsService>();
+    private readonly UserDetails _user = new() { Id = "user-1", DisplayName = "Scheduler" };
+
+    [Fact]
+    public async Task Should_skip_when_deployment_settings_are_missing()
+    {
+        var sut = CreateSut();
+
+        _deploymentsService.FindDeploymentSettings("service-a", "dev", Arg.Any<CancellationToken>())
+            .Returns((DeploymentSettings?)null);
+
+        await sut.DeployAsync("service-a", "1.2.3", "dev", _user, CancellationToken.None);
+
+        await _appConfigVersionsService.DidNotReceive()
+            .FindLatestAppConfigVersion(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _selfServiceOpsClient.DidNotReceive()
+            .AutoDeployService(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<UserDetails>(),
+                Arg.Any<DeploymentSettings>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_skip_when_config_version_is_missing()
+    {
+        var sut = CreateSut();
+        var settings = new DeploymentSettings { Cpu = "1024", Memory = "2048", InstanceCount = 1 };
+
+        _deploymentsService.FindDeploymentSettings("service-a", "dev", Arg.Any<CancellationToken>())
+            .Returns(settings);
+        _appConfigVersionsService.FindLatestAppConfigVersion("dev", Arg.Any<CancellationToken>())
+            .Returns((AppConfigVersion?)null);
+
+        await sut.DeployAsync("service-a", "1.2.3", "dev", _user, CancellationToken.None);
+
+        await _selfServiceOpsClient.DidNotReceive()
+            .AutoDeployService(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<UserDetails>(),
+                Arg.Any<DeploymentSettings>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_deploy_when_settings_and_config_exist()
+    {
+        var sut = CreateSut();
+        var settings = new DeploymentSettings { Cpu = "1024", Memory = "2048", InstanceCount = 1 };
+        var configVersion = new AppConfigVersion("abc123", DateTime.UtcNow, "dev");
+
+        _deploymentsService.FindDeploymentSettings("service-a", "dev", Arg.Any<CancellationToken>())
+            .Returns(settings);
+        _appConfigVersionsService.FindLatestAppConfigVersion("dev", Arg.Any<CancellationToken>())
+            .Returns(configVersion);
+
+        await sut.DeployAsync("service-a", "1.2.3", "dev", _user, CancellationToken.None);
+
+        await _selfServiceOpsClient.Received(1)
+            .AutoDeployService(
+                "service-a",
+                "1.2.3",
+                "dev",
+                _user,
+                settings,
+                "abc123",
+                Arg.Any<CancellationToken>());
+    }
+
+    private ServiceDeploymentExecutor CreateSut()
+    {
+        return new ServiceDeploymentExecutor(
+            _deploymentsService,
+            _selfServiceOpsClient,
+            _appConfigVersionsService,
+            NullLogger<ServiceDeploymentExecutor>.Instance);
+    }
+}

--- a/Defra.Cdp.Backend.Api.Tests/Services/Scheduler/MongoDeployServiceScheduleTaskTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Scheduler/MongoDeployServiceScheduleTaskTests.cs
@@ -1,0 +1,125 @@
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.Scheduler.Model;
+using Defra.Cdp.Backend.Api.Services.TenantArtifacts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Scheduler;
+
+public class MongoDeployServiceScheduleTaskTests
+{
+    [Fact]
+    public async Task Should_deploy_to_each_environment_when_due_and_artifact_exists()
+    {
+        var artifactsService = Substitute.For<IDeployableArtifactsService>();
+        var deploymentExecutor = Substitute.For<IServiceDeploymentExecutor>();
+        var serviceProvider = CreateProvider(artifactsService, deploymentExecutor);
+
+        artifactsService.FindLatest("cdp-canary-deployment-backend", Arg.Any<CancellationToken>())
+            .Returns(new DeployableArtifact
+            {
+                Repo = "cdp-canary-deployment-backend",
+                Tag = "1.2.3",
+                Sha256 = "sha256:abc"
+            });
+
+        var task = new MongoDeployServiceScheduleTask
+        {
+            EntityId = "cdp-canary-deployment-backend",
+            Environments = ["infra-dev", "prod"]
+        };
+
+        await task.ExecuteAsync(
+            serviceProvider,
+            DateTime.UtcNow,
+            NullLogger<object>.Instance,
+            CancellationToken.None);
+
+        await deploymentExecutor.Received(1).DeployAsync(
+            "cdp-canary-deployment-backend",
+            "1.2.3",
+            "infra-dev",
+            Arg.Is<UserDetails>(u => u.Id == "00000000-0000-0000-0000-00000000001"),
+            Arg.Any<CancellationToken>());
+
+        await deploymentExecutor.Received(1).DeployAsync(
+            "cdp-canary-deployment-backend",
+            "1.2.3",
+            "prod",
+            Arg.Is<UserDetails>(u => u.DisplayName == "Auto schedule"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_not_execute_when_next_run_is_too_old()
+    {
+        var artifactsService = Substitute.For<IDeployableArtifactsService>();
+        var deploymentExecutor = Substitute.For<IServiceDeploymentExecutor>();
+        var serviceProvider = CreateProvider(artifactsService, deploymentExecutor);
+
+        var task = new MongoDeployServiceScheduleTask
+        {
+            EntityId = "cdp-canary-deployment-backend",
+            Environments = ["infra-dev"]
+        };
+
+        await task.ExecuteAsync(
+            serviceProvider,
+            DateTime.UtcNow.AddMinutes(-10),
+            NullLogger<object>.Instance,
+            CancellationToken.None);
+
+        await artifactsService.DidNotReceive()
+            .FindLatest(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await deploymentExecutor.DidNotReceive()
+            .DeployAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<UserDetails>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Should_not_deploy_when_no_artifact_exists()
+    {
+        var artifactsService = Substitute.For<IDeployableArtifactsService>();
+        var deploymentExecutor = Substitute.For<IServiceDeploymentExecutor>();
+        var serviceProvider = CreateProvider(artifactsService, deploymentExecutor);
+
+        artifactsService.FindLatest("cdp-canary-deployment-backend", Arg.Any<CancellationToken>())
+            .Returns((DeployableArtifact?)null);
+
+        var task = new MongoDeployServiceScheduleTask
+        {
+            EntityId = "cdp-canary-deployment-backend",
+            Environments = ["infra-dev"]
+        };
+
+        await task.ExecuteAsync(
+            serviceProvider,
+            DateTime.UtcNow,
+            NullLogger<object>.Instance,
+            CancellationToken.None);
+
+        await deploymentExecutor.DidNotReceive()
+            .DeployAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<UserDetails>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    private static IServiceProvider CreateProvider(
+        IDeployableArtifactsService artifactsService,
+        IServiceDeploymentExecutor deploymentExecutor)
+    {
+        return new ServiceCollection()
+            .AddSingleton(artifactsService)
+            .AddSingleton(deploymentExecutor)
+            .BuildServiceProvider();
+    }
+}

--- a/Defra.Cdp.Backend.Api.Tests/Services/Scheduler/ScheduleExecutionWindowTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Scheduler/ScheduleExecutionWindowTests.cs
@@ -1,0 +1,34 @@
+using Defra.Cdp.Backend.Api.Services.Scheduler;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Scheduler;
+
+public class ScheduleExecutionWindowTests
+{
+    private static readonly DateTime Now = new(2025, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void IsDue_returns_false_when_nextRunAt_is_null()
+    {
+        Assert.False(ScheduleExecutionWindow.IsDue(null, Now));
+    }
+
+    [Theory]
+    [InlineData(0)]           // exactly now
+    [InlineData(1)]           // in the future
+    [InlineData(-1)]          // 1 minute ago
+    [InlineData(-5)]          // exactly at tolerance boundary
+    public void IsDue_returns_true_when_nextRunAt_is_within_tolerance(int minutesFromNow)
+    {
+        var nextRunAt = Now.AddMinutes(minutesFromNow);
+
+        Assert.True(ScheduleExecutionWindow.IsDue(nextRunAt, Now));
+    }
+
+    [Fact]
+    public void IsDue_returns_false_when_nextRunAt_is_before_tolerance_window()
+    {
+        var nextRunAt = Now.AddMinutes(-5).AddSeconds(-1);
+
+        Assert.False(ScheduleExecutionWindow.IsDue(nextRunAt, Now));
+    }
+}

--- a/Defra.Cdp.Backend.Api/Endpoints/EntitiesEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/EntitiesEndpoint.cs
@@ -150,6 +150,11 @@ public static class EntitiesEndpoint
             return TypedResults.Conflict("Entity is not a test suite");
         }
 
+        if (scheduleRequest.Task is EntityDeployServiceTask && entity.Type != Type.Microservice)
+        {
+            return TypedResults.Conflict("Entity is not a microservice");
+        }
+
         var mongoSchedule = ScheduleMapper.ToMongo(scheduleRequest, user, name);
         await schedulerService.Schedule(mongoSchedule, ct);
 
@@ -206,6 +211,11 @@ public static class EntitiesEndpoint
         if (scheduleRequest.Task is EntityTestSuiteTask && entity.Type != Type.TestSuite)
         {
             return TypedResults.Conflict("Entity is not a test suite");
+        }
+
+        if (scheduleRequest.Task is EntityDeployServiceTask && entity.Type != Type.Microservice)
+        {
+            return TypedResults.Conflict("Entity is not a microservice");
         }
         
         var mongoSchedule = ScheduleMapper.ToUpdatedMongo(scheduleRequest, originalSchedule, user, name);

--- a/Defra.Cdp.Backend.Api/Endpoints/SchedulesEndpoint.cs
+++ b/Defra.Cdp.Backend.Api/Endpoints/SchedulesEndpoint.cs
@@ -62,6 +62,21 @@ public static class SchedulesEndpoint
             }
         }
 
+        if (scheduleRequest.Task is DeployServiceTask deployServiceTask)
+        {
+            var entity = await entitiesService.GetEntity(deployServiceTask.EntityId, ct);
+
+            if (entity == null)
+            {
+                return TypedResults.NotFound("Entity not found");
+            }
+
+            if (entity.Type != Type.Microservice)
+            {
+                return TypedResults.Conflict("Entity is not a microservice");
+            }
+        }
+
         var mongoSchedule = ScheduleMapper.ToMongo(scheduleRequest, user);
 
         await schedulerService.Schedule(mongoSchedule, ct);

--- a/Defra.Cdp.Backend.Api/Models/Schedules/ScheduleConfig.cs
+++ b/Defra.Cdp.Backend.Api/Models/Schedules/ScheduleConfig.cs
@@ -157,5 +157,6 @@ public enum IntervalUnit
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TaskTypeEnum
 {
-    DeployTestSuite
+    DeployTestSuite,
+    DeployService
 }

--- a/Defra.Cdp.Backend.Api/Models/Schedules/ScheduleTask.cs
+++ b/Defra.Cdp.Backend.Api/Models/Schedules/ScheduleTask.cs
@@ -4,6 +4,7 @@ namespace Defra.Cdp.Backend.Api.Models.Schedules;
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(TestSuiteTask), "DeployTestSuite")]
+[JsonDerivedType(typeof(DeployServiceTask), "DeployService")]
 public abstract class ScheduleTask
 {
     [JsonIgnore] public TaskTypeEnum Type { get; protected set; }
@@ -23,9 +24,18 @@ public class TestSuiteTask : ScheduleTask
     [JsonPropertyName("profile")] public string? Profile { get; init; }
 }
 
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+public class DeployServiceTask : ScheduleTask
+{
+    [JsonPropertyName("entityId")] public required string EntityId { get; init; }
+
+    [JsonPropertyName("environments")] public required List<string> Environments { get; init; }
+}
+
 // entity tasks for entity endpoint (entityId is passed as path parameter & not all schedule tasks are entity scheduled tasks)
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(EntityTestSuiteTask), "DeployTestSuite")]
+[JsonDerivedType(typeof(EntityDeployServiceTask), "DeployService")]
 public abstract class EntityScheduleTask : ScheduleTask;
 
 [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
@@ -38,4 +48,10 @@ public class EntityTestSuiteTask : EntityScheduleTask
     [JsonPropertyName("memory")] public required int Memory { get; init; }
 
     [JsonPropertyName("profile")] public string? Profile { get; init; }
+}
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+public class EntityDeployServiceTask : EntityScheduleTask
+{
+    [JsonPropertyName("environments")] public required List<string> Environments { get; init; }
 }

--- a/Defra.Cdp.Backend.Api/Program.cs
+++ b/Defra.Cdp.Backend.Api/Program.cs
@@ -169,6 +169,7 @@ builder.Services.AddHostedService<QuartzSchedulersHostedService>();
 builder.Services.AddSingleton<IRepositoryService, RepositoryService>();
 builder.Services.AddSingleton<IDeployableArtifactsService, DeployableArtifactsService>();
 builder.Services.AddSingleton<IDeploymentsService, DeploymentsService>();
+builder.Services.AddSingleton<IServiceDeploymentExecutor, ServiceDeploymentExecutor>();
 builder.Services.AddSingleton<IEntitiesService, EntitiesService>();
 builder.Services.AddSingleton<IEntityTopologyService, EntityTopologyService>();
 builder.Services.AddSingleton<IEcrEventsService, EcrEventsService>();

--- a/Defra.Cdp.Backend.Api/Services/AutoDeploymentTriggers/AutoDeploymentTriggerExecutor.cs
+++ b/Defra.Cdp.Backend.Api/Services/AutoDeploymentTriggers/AutoDeploymentTriggerExecutor.cs
@@ -24,8 +24,9 @@ public class AutoDeploymentTriggerExecutor(
 {
     public async Task Handle(string repositoryName, string imageTag, CancellationToken cancellationToken)
     {
-        var autoDeploymentToggle = await featureTogglesService.GetToggle("auto-deployments", cancellationToken);
-        if (autoDeploymentToggle is { Active: true })
+        var disableAutoDeploymentsToggle =
+            await featureTogglesService.GetToggle("auto-deployments", cancellationToken);
+        if (disableAutoDeploymentsToggle is { Active: true })
         {
             logger.LogInformation("Auto-deployment feature is disabled, skipping auto-deployment for {RepositoryName}",
                 repositoryName);

--- a/Defra.Cdp.Backend.Api/Services/AutoDeploymentTriggers/AutoDeploymentTriggerExecutor.cs
+++ b/Defra.Cdp.Backend.Api/Services/AutoDeploymentTriggers/AutoDeploymentTriggerExecutor.cs
@@ -1,9 +1,7 @@
 using Defra.Cdp.Backend.Api.Models;
-using Defra.Cdp.Backend.Api.Services.Deployments;
 using Defra.Cdp.Backend.Api.Services.FeatureToggles;
-using Defra.Cdp.Backend.Api.Services.GithubWorkflowEvents.Services;
 using Defra.Cdp.Backend.Api.Utils.Auditing;
-using Defra.Cdp.Backend.Api.Utils.Clients;
+using Defra.Cdp.Backend.Api.Services.Deployments;
 
 namespace Defra.Cdp.Backend.Api.Services.AutoDeploymentTriggers;
 
@@ -19,9 +17,7 @@ public interface IAutoDeploymentTriggerExecutor
 
 public class AutoDeploymentTriggerExecutor(
     IAutoDeploymentTriggerService autoDeploymentTriggerService,
-    IDeploymentsService deploymentsService,
-    ISelfServiceOpsClient selfServiceOpsClient,
-    IAppConfigVersionsService appConfigVersionsService,
+    IServiceDeploymentExecutor serviceDeploymentExecutor,
     IFeatureTogglesService featureTogglesService,
     ILogger<AutoDeploymentTriggerExecutor> logger
 ) : IAutoDeploymentTriggerExecutor
@@ -47,40 +43,20 @@ public class AutoDeploymentTriggerExecutor(
         logger.LogInformation("Auto-deployment trigger found for {RepositoryName} to {Environments}",
             repositoryName, trigger.Environments);
 
+        var userDetails = new UserDetails
+        {
+            Id = AutoDeploymentConstants.AutoDeploymentId,
+            DisplayName = "Auto deployment"
+        };
+
         foreach (var environment in trigger.Environments)
         {
-            var deploymentSettings =
-                await deploymentsService.FindDeploymentSettings(repositoryName, environment, cancellationToken);
-            if (deploymentSettings == null)
-            {
-                logger.LogError(
-                    "Could not find deployment settings for repository {RepositoryName} in environment {Environment}",
-                    repositoryName, environment);
-                continue;
-            }
-
-            var configVersion =
-                await appConfigVersionsService.FindLatestAppConfigVersion(environment, cancellationToken);
-            if (configVersion == null)
-            {
-                logger.LogError("Could not find latest config version for environment: {Environment}", environment);
-                continue;
-            }
-
-            logger.LogInformation(
-                "Auto-deploying {RepositoryName} version {ImageTag} to {Environment}",
-                repositoryName, imageTag, environment);
-
-            var userDetails = new UserDetails
-            {
-                Id = AutoDeploymentConstants.AutoDeploymentId,
-                DisplayName = "Auto deployment"
-            };
-
-            await selfServiceOpsClient.AutoDeployService(repositoryName, imageTag, environment, userDetails,
-                deploymentSettings, configVersion.CommitSha, cancellationToken);
-
-            logger.Audit("Auto-deploying {Repo}:{Version} to {Environment}", repositoryName, imageTag, environment);
+            await serviceDeploymentExecutor.DeployAsync(
+                repositoryName,
+                imageTag,
+                environment,
+                userDetails,
+                cancellationToken);
         }
     }
 }

--- a/Defra.Cdp.Backend.Api/Services/Deployments/ServiceDeploymentExecutor.cs
+++ b/Defra.Cdp.Backend.Api/Services/Deployments/ServiceDeploymentExecutor.cs
@@ -1,0 +1,64 @@
+using Defra.Cdp.Backend.Api.Models;
+using Defra.Cdp.Backend.Api.Services.GithubWorkflowEvents.Services;
+using Defra.Cdp.Backend.Api.Utils.Auditing;
+using Defra.Cdp.Backend.Api.Utils.Clients;
+
+namespace Defra.Cdp.Backend.Api.Services.Deployments;
+
+public interface IServiceDeploymentExecutor
+{
+    Task DeployAsync(
+        string repositoryName,
+        string imageTag,
+        string environment,
+        UserDetails user,
+        CancellationToken cancellationToken);
+}
+
+public class ServiceDeploymentExecutor(
+    IDeploymentsService deploymentsService,
+    ISelfServiceOpsClient selfServiceOpsClient,
+    IAppConfigVersionsService appConfigVersionsService,
+    ILogger<ServiceDeploymentExecutor> logger) : IServiceDeploymentExecutor
+{
+    public async Task DeployAsync(
+        string repositoryName,
+        string imageTag,
+        string environment,
+        UserDetails user,
+        CancellationToken cancellationToken)
+    {
+        var deploymentSettings =
+            await deploymentsService.FindDeploymentSettings(repositoryName, environment, cancellationToken);
+        if (deploymentSettings == null)
+        {
+            logger.LogError(
+                "Could not find deployment settings for repository {RepositoryName} in environment {Environment}",
+                repositoryName, environment);
+            return;
+        }
+
+        var configVersion =
+            await appConfigVersionsService.FindLatestAppConfigVersion(environment, cancellationToken);
+        if (configVersion == null)
+        {
+            logger.LogError("Could not find latest config version for environment: {Environment}", environment);
+            return;
+        }
+
+        logger.LogInformation(
+            "Auto-deploying {RepositoryName} version {ImageTag} to {Environment}",
+            repositoryName, imageTag, environment);
+
+        await selfServiceOpsClient.AutoDeployService(
+            repositoryName,
+            imageTag,
+            environment,
+            user,
+            deploymentSettings,
+            configVersion.CommitSha,
+            cancellationToken);
+
+        logger.Audit("Auto-deploying {Repo}:{Version} to {Environment}", repositoryName, imageTag, environment);
+    }
+}

--- a/Defra.Cdp.Backend.Api/Services/Scheduler/Mapping/ScheduleMapper.cs
+++ b/Defra.Cdp.Backend.Api/Services/Scheduler/Mapping/ScheduleMapper.cs
@@ -54,24 +54,4 @@ public static class ScheduleMapper
             mongoUser
         );
     }
-
-    public static MongoSchedule ToUpdatedMongo(ScheduleRequest schedule, MongoSchedule originalSchedule, UserDetails user, string entityId)
-    {
-        var task = ScheduleTaskMapper.ToMongo(schedule.Task);
-        var config = ScheduleConfigMapper.ToMongo(schedule.Config);
-        var mongoUser = new MongoUserDetails { Id = user.Id, DisplayName = user.DisplayName };
-        var updatedSchedule = originalSchedule with
-        {
-            Enabled = schedule.Enabled,
-            Cron = schedule.Config.GetCronExpression(),
-            Description = schedule.Config.GetDescription(),
-            Config = config,
-            Task = task,
-            User = mongoUser
-        };
-
-        updatedSchedule.RecalculateNextRun();
-        return updatedSchedule;
-    }
-
 }

--- a/Defra.Cdp.Backend.Api/Services/Scheduler/Mapping/ScheduleTaskMapper.cs
+++ b/Defra.Cdp.Backend.Api/Services/Scheduler/Mapping/ScheduleTaskMapper.cs
@@ -17,6 +17,11 @@ public static class ScheduleTaskMapper
                 Memory = ts.Memory,
                 Profile = ts.Profile
             },
+            DeployServiceTask ds => new MongoDeployServiceScheduleTask
+            {
+                EntityId = ds.EntityId,
+                Environments = ds.Environments
+            },
             // add other task types here...
             _ => throw new NotSupportedException($"Unknown task type {task.GetType()}")
         };
@@ -34,6 +39,11 @@ public static class ScheduleTaskMapper
                 Cpu = ts.Cpu,
                 Memory = ts.Memory,
                 Profile = ts.Profile
+            },
+            EntityDeployServiceTask ds => new MongoDeployServiceScheduleTask
+            {
+                EntityId = entityId,
+                Environments = ds.Environments
             },
             // add other task types here...
             _ => throw new NotSupportedException($"Unknown task type {task.GetType()}")

--- a/Defra.Cdp.Backend.Api/Services/Scheduler/Model/MongoScheduleTask.cs
+++ b/Defra.Cdp.Backend.Api/Services/Scheduler/Model/MongoScheduleTask.cs
@@ -1,6 +1,9 @@
 using System.Text.Json.Serialization;
+using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Models.Schedules;
+using Defra.Cdp.Backend.Api.Services.Deployments;
 using Defra.Cdp.Backend.Api.Services.Scheduler.TestSuiteDeployment;
+using Defra.Cdp.Backend.Api.Services.TenantArtifacts;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -8,6 +11,7 @@ namespace Defra.Cdp.Backend.Api.Services.Scheduler.Model;
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(MongoTestSuiteScheduleTask), nameof(TaskTypeEnum.DeployTestSuite))]
+[JsonDerivedType(typeof(MongoDeployServiceScheduleTask), nameof(TaskTypeEnum.DeployService))]
 public abstract class MongoScheduleTask
 {
     [BsonRepresentation(BsonType.String)]
@@ -61,6 +65,63 @@ public class MongoTestSuiteScheduleTask : MongoScheduleTask
             logger.LogWarning(
                 "Not executing test-suite {testSuite} to {environment} with next run at {nextRunAt}",
                 EntityId, Environment, nextRunAt);
+        }
+    }
+}
+
+public class MongoDeployServiceScheduleTask : MongoScheduleTask
+{
+    [JsonIgnore] public override TaskTypeEnum Type { get; protected set; } = TaskTypeEnum.DeployService;
+    public override required string EntityId { get; init; }
+    public required List<string> Environments { get; init; }
+
+    public override async Task ExecuteAsync(
+        IServiceProvider services,
+        DateTime? nextRunAt,
+        ILogger<object> logger,
+        CancellationToken ct)
+    {
+        var artifactsService = services.GetRequiredService<IDeployableArtifactsService>();
+        var serviceDeploymentExecutor = services.GetRequiredService<IServiceDeploymentExecutor>();
+
+        var now = DateTime.UtcNow;
+        var tolerance = TimeSpan.FromMinutes(5);
+        var shouldExecute =
+            nextRunAt.HasValue &&
+            nextRunAt.Value >= now - tolerance;
+
+        if (!shouldExecute)
+        {
+            logger.LogWarning(
+                "Not executing service deployment for {service} with next run at {nextRunAt}",
+                EntityId,
+                nextRunAt);
+            return;
+        }
+
+        var latestArtifact = await artifactsService.FindLatest(EntityId, ct);
+        if (latestArtifact == null)
+        {
+            logger.LogError(
+                "Could not find latest artifact for service {service}. Skipping scheduled deployment.",
+                EntityId);
+            return;
+        }
+
+        var user = new UserDetails
+        {
+            Id = ScheduledTestRunConstants.UserId,
+            DisplayName = ScheduledTestRunConstants.DisplayName
+        };
+
+        foreach (var environment in Environments)
+        {
+            await serviceDeploymentExecutor.DeployAsync(
+                EntityId,
+                latestArtifact.Tag,
+                environment,
+                user,
+                ct);
         }
     }
 }

--- a/Defra.Cdp.Backend.Api/Services/Scheduler/Model/MongoScheduleTask.cs
+++ b/Defra.Cdp.Backend.Api/Services/Scheduler/Model/MongoScheduleTask.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Models.Schedules;
 using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.Scheduler;
 using Defra.Cdp.Backend.Api.Services.Scheduler.TestSuiteDeployment;
 using Defra.Cdp.Backend.Api.Services.TenantArtifacts;
 using MongoDB.Bson;
@@ -44,13 +45,7 @@ public class MongoTestSuiteScheduleTask : MongoScheduleTask
     {
         var deployer = services.GetRequiredService<ITestSuiteDeployer>();
 
-        var now = DateTime.UtcNow;
-        var tolerance = TimeSpan.FromMinutes(5);
-        var shouldExecute =
-            nextRunAt.HasValue &&
-            nextRunAt.Value >= now - tolerance;
-
-        if (shouldExecute)
+        if (ScheduleExecutionWindow.IsDue(nextRunAt))
         {
             await deployer.DeployAsync(
                 EntityId,
@@ -84,13 +79,7 @@ public class MongoDeployServiceScheduleTask : MongoScheduleTask
         var artifactsService = services.GetRequiredService<IDeployableArtifactsService>();
         var serviceDeploymentExecutor = services.GetRequiredService<IServiceDeploymentExecutor>();
 
-        var now = DateTime.UtcNow;
-        var tolerance = TimeSpan.FromMinutes(5);
-        var shouldExecute =
-            nextRunAt.HasValue &&
-            nextRunAt.Value >= now - tolerance;
-
-        if (!shouldExecute)
+        if (!ScheduleExecutionWindow.IsDue(nextRunAt))
         {
             logger.LogWarning(
                 "Not executing service deployment for {service} with next run at {nextRunAt}",

--- a/Defra.Cdp.Backend.Api/Services/Scheduler/ScheduleExecutionWindow.cs
+++ b/Defra.Cdp.Backend.Api/Services/Scheduler/ScheduleExecutionWindow.cs
@@ -1,0 +1,12 @@
+namespace Defra.Cdp.Backend.Api.Services.Scheduler;
+
+internal static class ScheduleExecutionWindow
+{
+    private static readonly TimeSpan Tolerance = TimeSpan.FromMinutes(5);
+
+    public static bool IsDue(DateTime? nextRunAt, DateTime? now = null)
+    {
+        now ??= DateTime.UtcNow;
+        return nextRunAt.HasValue && nextRunAt.Value >= now.Value - Tolerance;
+    }
+}

--- a/Defra.Cdp.Backend.Api/Services/Scheduler/ScheduleExecutionWindow.cs
+++ b/Defra.Cdp.Backend.Api/Services/Scheduler/ScheduleExecutionWindow.cs
@@ -1,6 +1,6 @@
 namespace Defra.Cdp.Backend.Api.Services.Scheduler;
 
-internal static class ScheduleExecutionWindow
+public static class ScheduleExecutionWindow
 {
     private static readonly TimeSpan Tolerance = TimeSpan.FromMinutes(5);
 

--- a/Defra.Cdp.Backend.Api/Services/Scheduler/SchedulerPoller.cs
+++ b/Defra.Cdp.Backend.Api/Services/Scheduler/SchedulerPoller.cs
@@ -27,7 +27,6 @@ public class SchedulerPoller(
 
             var ct = context.CancellationToken;
             var now = DateTime.UtcNow;
-            var tolerance = TimeSpan.FromMinutes(5);
 
             var dueSchedules = await schedulerService.FetchDueSchedules(ct);
 
@@ -35,13 +34,10 @@ public class SchedulerPoller(
             {
                 _logger.LogInformation("Processing schedule {id} for entity {entityId} and description {description}",
                     schedule.Id, schedule.Task.EntityId, schedule.Description);
-                var shouldExecute =
-                    schedule.NextRunAt.HasValue &&
-                    schedule.NextRunAt.Value >= now - tolerance;
 
                 using var scope = serviceProvider.CreateScope();
 
-                if (shouldExecute)
+                if (ScheduleExecutionWindow.IsDue(schedule.NextRunAt, now))
                 {
                     try
                     {


### PR DESCRIPTION
Re-enables nightly canary service deployments by adding a scheduled DeployService task to the portal backend scheduler.

- extract shared deployment logic 
- finds latest artifact and deploys to each configured environment via Self Service Ops `POST /auto-deploy-service`
- validate `DeployService` schedules
- refactor `AutoDeploymentTriggerExecutor` to delegate per-environment deploy to the shared executor (auto-deploy prod-stripping behaviour unchanged)
