### PR TITLE
CORE-3242: Register MongoDeployServiceScheduleTask for BSON deserialization so DeployService schedules survive API restarts

### DIFF
--- a/Defra.Cdp.Backend.Api/Program.cs
+++ b/Defra.Cdp.Backend.Api/Program.cs
@@ -117,6 +117,7 @@ if (!BsonClassMap.IsClassMapRegistered(typeof(MongoScheduleTask)))
         cm.AutoMap();
         cm.SetIsRootClass(true);
         cm.AddKnownType(typeof(MongoTestSuiteScheduleTask));
+        cm.AddKnownType(typeof(MongoDeployServiceScheduleTask));
     });
 }
 


### PR DESCRIPTION
Add MongoDeployServiceScheduleTask to Mongo AddKnownType so GET/PATCH and the scheduler can read DeployService schedules after a cold start.