### PR TITLE
CORE-3293: Read stored waf_web_acl for shutter-v2 environments

### DIFF
--- a/Defra.Cdp.Backend.Api.IntegrationTests/Services/Shuttering/ShutteringTests.cs
+++ b/Defra.Cdp.Backend.Api.IntegrationTests/Services/Shuttering/ShutteringTests.cs
@@ -4,6 +4,7 @@ using Defra.Cdp.Backend.Api.Services.Entities;
 using Defra.Cdp.Backend.Api.Services.Entities.Model;
 using Defra.Cdp.Backend.Api.Services.MonoLambda.Models;
 using Defra.Cdp.Backend.Api.Services.Shuttering;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
 
@@ -11,6 +12,7 @@ namespace Defra.Cdp.Backend.Api.IntegrationTests.Services.Shuttering;
 
 public class ShutteringTests(MongoContainerFixture fixture) : MongoTestSupport(fixture)
 {
+    private static IConfiguration EmptyConfig() => new ConfigurationBuilder().Build();
 
     [Fact]
     public async Task TestShutteringStatus()
@@ -18,7 +20,7 @@ public class ShutteringTests(MongoContainerFixture fixture) : MongoTestSupport(f
         var connectionFactory = CreateMongoDbClientFactory();
         var entityService = new EntitiesService(connectionFactory, new NullLoggerFactory());
         var shutteringArchiveService = new ShutteringArchiveService(connectionFactory, new NullLoggerFactory());
-        var shutteringService = new ShutteringService(connectionFactory, entityService, shutteringArchiveService, new NullLoggerFactory());
+        var shutteringService = new ShutteringService(connectionFactory, entityService, shutteringArchiveService, EmptyConfig(), new NullLoggerFactory());
         var ct = TestContext.Current.CancellationToken;
 
         await entityService.Create(_entity, ct);
@@ -44,7 +46,7 @@ public class ShutteringTests(MongoContainerFixture fixture) : MongoTestSupport(f
         var entitiesCollection = connectionFactory.GetCollection<Entity>("entities");
         var entityService = new EntitiesService(connectionFactory, new NullLoggerFactory());
         var shutteringArchiveService = new ShutteringArchiveService(connectionFactory, new NullLoggerFactory());
-        var shutteringService = new ShutteringService(connectionFactory, entityService, shutteringArchiveService, new NullLoggerFactory());
+        var shutteringService = new ShutteringService(connectionFactory, entityService, shutteringArchiveService, EmptyConfig(), new NullLoggerFactory());
         var ct = TestContext.Current.CancellationToken;
 
         await entityService.Create(_entity, ct);

--- a/Defra.Cdp.Backend.Api/Services/MonoLambda/Models/TenantData.cs
+++ b/Defra.Cdp.Backend.Api/Services/MonoLambda/Models/TenantData.cs
@@ -598,11 +598,14 @@ public class TenantUrl
     [property: JsonPropertyName("ingress_type")]
     public string? IngressType { get; set; }
 
+    [property: JsonPropertyName("waf_web_acl")]
+    public string? WafWebAcl { get; set; }
+
 }
 
 public static class TenantDataVersion
 {
-    public static readonly string Version = "1acfca3bd12d19991e9006131ba448129b50b4fe25e932911a130b1c687906ac";
+    public static readonly string Version = "35e85d5662d5b62def16a18ae05cafbdcb9cd0a375e01a6709deeacb61f71762";
 }
 
 

--- a/Defra.Cdp.Backend.Api/Services/Shuttering/ShutteringService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Shuttering/ShutteringService.cs
@@ -17,11 +17,19 @@ public class ShutteringService(
     IMongoDbClientFactory connectionFactory,
     IEntitiesService entitiesService,
     IShutteringArchiveService shutteringArchiveService,
+    IConfiguration configuration,
     ILoggerFactory loggerFactory)
     : MongoService<ShutteringRecord>(connectionFactory,
         CollectionName, loggerFactory), IShutteringService
 {
     private const string CollectionName = "shutteringrecords";
+
+    private readonly ILogger<ShutteringService> _logger = loggerFactory.CreateLogger<ShutteringService>();
+
+    private readonly HashSet<string> _shutterV2Environments =
+        (configuration.GetValue<string>("ShutterV2Environments") ?? "")
+        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     public async Task Register(ShutteringRecord shutteringRecord, CancellationToken cancellationToken)
     {
@@ -57,7 +65,7 @@ public class ShutteringService(
 
                 var status = ShutteringStatus(requestedState?.Shuttered, urlData.Shuttered);
                 var urlType = UrlToWafUrlType(url, envConfig);
-                var waf = UrlToWaf(url, envConfig);
+                var waf = ResolveWaf(env, url, envConfig, urlData);
                 
                 output.Add(new ShutteringUrlState
                 {
@@ -97,16 +105,38 @@ public class ShutteringService(
             (false, false) => Models.ShutteringStatus.Active
         };
     }
-    
+
     /// <summary>
+    /// Resolves the WAF ACL for a URL: stored value for shutter-v2 environments, legacy heuristic otherwise.
+    /// Logs a warning if a shutter-v2 environment is missing the stored value.
+    /// </summary>
+    private string? ResolveWaf(string env, string url, CdpTenant envConfig, TenantUrl urlData)
+    {
+        if (!_shutterV2Environments.Contains(env))
+        {
+            return LegacyUrlToWaf(url, envConfig);
+        }
+
+        if (urlData.WafWebAcl == null)
+        {
+            _logger.LogWarning(
+                "Missing waf_web_acl for shutter-v2 environment {Environment}, url {Url}. " +
+                "Platform state may not have been republished since this URL was added, or cdp-tf-waf " +
+                "isn't tracking it yet.", env, url);
+        }
+
+        return urlData.WafWebAcl;
+    }
+
+    /// <summary>
+    /// Computes the WAF ACL category from tenant config. Used only for environments not yet on shutter v2.
     /// See: https://github.com/DEFRA/cdp-platform-documentation/blob/main/infrastructure/shuttering.md
-    /// This will only be needed in the short-term. Shuttering is going to be reworked so we dont need
-    /// to explicitly pass the WAF as a parameter.
+    /// Remove once shutter v2 has fully rolled out.
     /// </summary>
     /// <param name="url"></param>
     /// <param name="envConfig"></param>
     /// <returns></returns>
-    public static string UrlToWaf(string url, CdpTenant envConfig)
+    public static string LegacyUrlToWaf(string url, CdpTenant envConfig)
     {
         var isPublic = envConfig.TenantConfig?.Zone == "public";
         var isNginx = envConfig.Nginx?.Servers.ContainsKey(url);

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -28,6 +28,7 @@
     "PollIntervalSecs": 20
   },
   "MigrationsBucket": "cdp-migrations",
+  "ShutterV2Environments": "infra-dev",
   "SelfServiceOpsSecret": "9fb76f1abc39a08f3147fcdb5cb7ad9cb8dc3609af47c0553b81ac116109e070",
   "DetailedErrors": true,
   "AllowedHosts": "*",

--- a/Defra.Cdp.Backend.Api/appsettings.json
+++ b/Defra.Cdp.Backend.Api/appsettings.json
@@ -43,6 +43,7 @@
     },
     "PollIntervalSecs": 1800
   },
+  "ShutterV2Environments": "",
   "UserServiceBackendUrl": "http://localhost:3001",
   "SelfServiceOpsUrl": "http://localhost:3009",
   "SbomExplorerBackendUrl": "http://localhost:3003",


### PR DESCRIPTION
- TenantData.cs: Waf → WafWebAcl (waf_web_acl JSON key), regenerated TenantDataVersion hash
- ShutteringService.cs: replaced implicit ?? UrlToWaf(...) null-fallback with explicit ShutterV2Environments-based branch (ResolveWaf); logs a warning if a shutter-v2 env is missing the stored value instead of silently falling back
- Renamed UrlToWaf → LegacyUrlToWaf with a comment to remove once v2 fully rolled out
- Added ShutterV2Environments config (appsettings.json default empty, appsettings.Development.json set to infra-dev for local dev)
- Updated integration tests for new constructor param