### PR TITLE
CORE-3471: Add shutter notifications

### DIFF
--- a/Defra.Cdp.Backend.Api.IntegrationTests/Services/Shuttering/ShutteringTests.cs
+++ b/Defra.Cdp.Backend.Api.IntegrationTests/Services/Shuttering/ShutteringTests.cs
@@ -3,10 +3,12 @@ using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Services.Entities;
 using Defra.Cdp.Backend.Api.Services.Entities.Model;
 using Defra.Cdp.Backend.Api.Services.MonoLambda.Models;
+using Defra.Cdp.Backend.Api.Services.Notifications;
 using Defra.Cdp.Backend.Api.Services.Shuttering;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
+using NSubstitute;
 
 namespace Defra.Cdp.Backend.Api.IntegrationTests.Services.Shuttering;
 
@@ -20,7 +22,8 @@ public class ShutteringTests(MongoContainerFixture fixture) : MongoTestSupport(f
         var connectionFactory = CreateMongoDbClientFactory();
         var entityService = new EntitiesService(connectionFactory, new NullLoggerFactory());
         var shutteringArchiveService = new ShutteringArchiveService(connectionFactory, new NullLoggerFactory());
-        var shutteringService = new ShutteringService(connectionFactory, entityService, shutteringArchiveService, EmptyConfig(), new NullLoggerFactory());
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var shutteringService = new ShutteringService(connectionFactory, entityService, shutteringArchiveService, notificationDispatcher, EmptyConfig(), new NullLoggerFactory());
         var ct = TestContext.Current.CancellationToken;
 
         await entityService.Create(_entity, ct);
@@ -37,6 +40,13 @@ public class ShutteringTests(MongoContainerFixture fixture) : MongoTestSupport(f
 
         var missingState = await shutteringService.ShutteringStatesForService(_entity.Name, "bar.com", ct);
         Assert.Null(missingState);
+
+        await notificationDispatcher.Received(1).Dispatch(
+            Arg.Is<ShutteredEvent>(e =>
+                e.Entity == _entity.Name &&
+                e.Environment == "prod" &&
+                e.Url == "foo.com"),
+            ct);
     }
 
     [Fact]
@@ -46,7 +56,8 @@ public class ShutteringTests(MongoContainerFixture fixture) : MongoTestSupport(f
         var entitiesCollection = connectionFactory.GetCollection<Entity>("entities");
         var entityService = new EntitiesService(connectionFactory, new NullLoggerFactory());
         var shutteringArchiveService = new ShutteringArchiveService(connectionFactory, new NullLoggerFactory());
-        var shutteringService = new ShutteringService(connectionFactory, entityService, shutteringArchiveService, EmptyConfig(), new NullLoggerFactory());
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var shutteringService = new ShutteringService(connectionFactory, entityService, shutteringArchiveService, notificationDispatcher, EmptyConfig(), new NullLoggerFactory());
         var ct = TestContext.Current.CancellationToken;
 
         await entityService.Create(_entity, ct);
@@ -88,6 +99,9 @@ public class ShutteringTests(MongoContainerFixture fixture) : MongoTestSupport(f
         status = await shutteringService.ShutteringStatesForService(_entity.Name, "foo.com", ct);
         Assert.NotNull(status);
         Assert.Equal(ShutteringStatus.Active, status.Status);
+
+        await notificationDispatcher.Received(1).Dispatch(Arg.Any<ShutteredEvent>(), ct);
+        await notificationDispatcher.Received(1).Dispatch(Arg.Any<UnshutteredEvent>(), ct);
     }
 
 

--- a/Defra.Cdp.Backend.Api.Tests/Services/Notifications/NotificationOptionsLookupTest.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Notifications/NotificationOptionsLookupTest.cs
@@ -77,7 +77,9 @@ public class NotificationOptionsLookupTest
 
         Assert.Collection(options,
             option => AssertOption(option, NotificationTypes.DeploymentFailed, Prod, PerfTest, Dev, Test, Management),
-            option => AssertOption(option, NotificationTypes.DeploymentSuccess, Prod, PerfTest, Dev, Test, Management));
+            option => AssertOption(option, NotificationTypes.DeploymentSuccess, Prod, PerfTest, Dev, Test, Management),
+            option => AssertOption(option, NotificationTypes.Shuttered, Prod, PerfTest, Dev, Test, Management),
+            option => AssertOption(option, NotificationTypes.Unshuttered, Prod, PerfTest, Dev, Test, Management));
     }
 
     private static void AssertOption(NotificationOptions option, string eventType, params string[] environments)

--- a/Defra.Cdp.Backend.Api.Tests/Services/Notifications/ShutteringNotificationTemplateTest.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Notifications/ShutteringNotificationTemplateTest.cs
@@ -1,0 +1,46 @@
+using Defra.Cdp.Backend.Api.Services.Notifications;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Notifications;
+
+public class ShutteringNotificationTemplateTest
+{
+    [Fact]
+    public void Shuttered_template_contains_expected_values()
+    {
+        var message = new ShutteredEvent
+        {
+            Entity = "svc-a",
+            Environment = "dev",
+            Url = "foo.example.com",
+            ActionedByDisplayName = "Jane Doe"
+        }.SlackMessage();
+
+        var header = message.Blocks?.FirstOrDefault()?.Text?.Text;
+        var fields = message.Blocks?.Skip(1).FirstOrDefault()?.Fields?.Select(f => f.Text ?? string.Empty).ToList() ?? [];
+
+        Assert.Equal("🟧 svc-a has been shuttered", header);
+        Assert.Contains("*Environment:*\ndev", fields);
+        Assert.Contains("*URL:*\nfoo.example.com", fields);
+        Assert.Contains("*Actioned by:*\nJane Doe", fields);
+    }
+
+    [Fact]
+    public void Unshuttered_template_contains_expected_values()
+    {
+        var message = new UnshutteredEvent
+        {
+            Entity = "svc-a",
+            Environment = "dev",
+            Url = "foo.example.com",
+            ActionedByDisplayName = "Jane Doe"
+        }.SlackMessage();
+
+        var header = message.Blocks?.FirstOrDefault()?.Text?.Text;
+        var fields = message.Blocks?.Skip(1).FirstOrDefault()?.Fields?.Select(f => f.Text ?? string.Empty).ToList() ?? [];
+
+        Assert.Equal("✅ svc-a has been unshuttered", header);
+        Assert.Contains("*Environment:*\ndev", fields);
+        Assert.Contains("*URL:*\nfoo.example.com", fields);
+        Assert.Contains("*Actioned by:*\nJane Doe", fields);
+    }
+}

--- a/Defra.Cdp.Backend.Api/Services/Notifications/NotificationEvents.cs
+++ b/Defra.Cdp.Backend.Api/Services/Notifications/NotificationEvents.cs
@@ -9,6 +9,8 @@ public static class NotificationTypes
     public const string TestPassed = "testpassed";
     public const string DeploymentFailed = "deploymentfailed";
     public const string DeploymentSuccess = "deploymentsuccess";
+    public const string Shuttered = "shuttered";
+    public const string Unshuttered = "unshuttered";
     public const string TenantResourceRequested = "tenantresourcerequested";
 
     public static readonly string[] All =
@@ -17,6 +19,8 @@ public static class NotificationTypes
         TestFailed,
         DeploymentFailed,
         DeploymentSuccess,
+        Shuttered,
+        Unshuttered,
         TenantResourceRequested
     ];
 }
@@ -85,6 +89,34 @@ public class DeploymentSuccessEvent : INotificationEvent
     public SlackMessageBody SlackMessage()
     {
         return SlackMessageTemplates.DeploymentSuccessTemplate(this);
+    }
+}
+
+public class ShutteredEvent : INotificationEvent
+{
+    public string EventType => NotificationTypes.Shuttered;
+    public required string Entity { get; init; }
+    public required string? Environment { get; init; }
+    public required string Url { get; init; }
+    public string? ActionedByDisplayName { get; init; }
+
+    public SlackMessageBody SlackMessage()
+    {
+        return SlackMessageTemplates.ShutteredTemplate(this);
+    }
+}
+
+public class UnshutteredEvent : INotificationEvent
+{
+    public string EventType => NotificationTypes.Unshuttered;
+    public required string Entity { get; init; }
+    public required string? Environment { get; init; }
+    public required string Url { get; init; }
+    public string? ActionedByDisplayName { get; init; }
+
+    public SlackMessageBody SlackMessage()
+    {
+        return SlackMessageTemplates.UnshutteredTemplate(this);
     }
 }
 

--- a/Defra.Cdp.Backend.Api/Services/Notifications/NotificationOptions.cs
+++ b/Defra.Cdp.Backend.Api/Services/Notifications/NotificationOptions.cs
@@ -34,9 +34,18 @@ public static class NotificationOptionLookup
                     EventType = NotificationTypes.DeploymentSuccess,
                     Environments = entity.Environments.Keys.ToList()
                 });
-            
+
                 // Shuttering
-                // Todo: When we add shuttering, loop though the envs and check if they have any shutter-able urls.
+                options.Add(new NotificationOptions
+                {
+                    EventType = NotificationTypes.Shuttered,
+                    Environments = entity.Environments.Keys.ToList()
+                });
+                options.Add(new NotificationOptions
+                {
+                    EventType = NotificationTypes.Unshuttered,
+                    Environments = entity.Environments.Keys.ToList()
+                });
                 break;
             case Type.TestSuite:
                 var envs = entity.Environments.Keys.ToList();

--- a/Defra.Cdp.Backend.Api/Services/Notifications/Slack/Templates/ShutteringTemplate.cs
+++ b/Defra.Cdp.Backend.Api/Services/Notifications/Slack/Templates/ShutteringTemplate.cs
@@ -1,0 +1,71 @@
+using Defra.Cdp.Backend.Api.Utils;
+
+namespace Defra.Cdp.Backend.Api.Services.Notifications.Slack.Templates;
+
+public static partial class SlackMessageTemplates
+{
+    public static SlackMessageBody ShutteredTemplate(ShutteredEvent e)
+    {
+        return ShutteringTemplate(
+            eventName: "shuttered",
+            headerPrefix: "🟧",
+            actor: e.ActionedByDisplayName,
+            entity: e.Entity,
+            environment: e.Environment,
+            url: e.Url);
+    }
+
+    public static SlackMessageBody UnshutteredTemplate(UnshutteredEvent e)
+    {
+        return ShutteringTemplate(
+            eventName: "unshuttered",
+            headerPrefix: "✅",
+            actor: e.ActionedByDisplayName,
+            entity: e.Entity,
+            environment: e.Environment,
+            url: e.Url);
+    }
+
+    private static SlackMessageBody ShutteringTemplate(
+        string eventName,
+        string headerPrefix,
+        string? actor,
+        string entity,
+        string? environment,
+        string url)
+    {
+        var maintenanceUri = new UriBuilder(PortalPublicUrl.BaseUri()) { Path = $"/services/{entity}/maintenance" };
+
+        return new SlackMessageBody
+        {
+            Blocks =
+            [
+                new Block
+                {
+                    Type = "header",
+                    Text = new TextObject
+                    {
+                        Type = "plain_text",
+                        Text = $"{headerPrefix} {entity} has been {eventName}",
+                        Emoji = true
+                    }
+                },
+                new Block
+                {
+                    Type = "section",
+                    Fields =
+                    [
+                        new TextObject { Type = "mrkdwn", Text = $"*Environment:*\n{EscapeMarkdown(environment ?? "")}" },
+                        new TextObject { Type = "mrkdwn", Text = $"*URL:*\n{EscapeMarkdown(url)}" },
+                        new TextObject { Type = "mrkdwn", Text = $"*Actioned by:*\n{EscapeMarkdown(actor ?? "Unknown")}" },
+                        new TextObject
+                        {
+                            Type = "mrkdwn",
+                            Text = $"*View details:*\n<{maintenanceUri.Uri.AbsoluteUri}|Open in portal>"
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+}

--- a/Defra.Cdp.Backend.Api/Services/Shuttering/ShutteringService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Shuttering/ShutteringService.cs
@@ -2,6 +2,7 @@ using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Mongo;
 using Defra.Cdp.Backend.Api.Services.Entities;
 using Defra.Cdp.Backend.Api.Services.MonoLambda.Models;
+using Defra.Cdp.Backend.Api.Services.Notifications;
 using MongoDB.Driver;
 
 namespace Defra.Cdp.Backend.Api.Services.Shuttering;
@@ -17,6 +18,7 @@ public class ShutteringService(
     IMongoDbClientFactory connectionFactory,
     IEntitiesService entitiesService,
     IShutteringArchiveService shutteringArchiveService,
+    INotificationDispatcher notificationDispatcher,
     IConfiguration configuration,
     ILoggerFactory loggerFactory)
     : MongoService<ShutteringRecord>(connectionFactory,
@@ -45,6 +47,7 @@ public class ShutteringService(
             cancellationToken);
 
         await shutteringArchiveService.Archive(shutteringRecord, cancellationToken);
+        await notificationDispatcher.Dispatch(MapToEvent(shutteringRecord), cancellationToken);
     }
 
     public async Task<List<ShutteringUrlState>> ShutteringStatesForService(string name,
@@ -174,5 +177,27 @@ public class ShutteringService(
         var service = new CreateIndexModel<ShutteringRecord>(builder.Descending(s => s.ServiceName)
         );
         return [service];
+    }
+
+    private static INotificationEvent MapToEvent(ShutteringRecord shutteringRecord)
+    {
+        if (shutteringRecord.Shuttered)
+        {
+            return new ShutteredEvent
+            {
+                Entity = shutteringRecord.ServiceName,
+                Environment = shutteringRecord.Environment,
+                Url = shutteringRecord.Url,
+                ActionedByDisplayName = shutteringRecord.ActionedBy.DisplayName
+            };
+        }
+
+        return new UnshutteredEvent
+        {
+            Entity = shutteringRecord.ServiceName,
+            Environment = shutteringRecord.Environment,
+            Url = shutteringRecord.Url,
+            ActionedByDisplayName = shutteringRecord.ActionedBy.DisplayName
+        };
     }
 }


### PR DESCRIPTION
Slack fires when the shutter intent is registered, roughly when the user acts — not when mono-lambda/platform_state confirms the URL is actually shuttered.