### PR TITLE
CORE-3697: Guard ECS deployment instance updates against out-of-order events

### DIFF
--- a/Defra.Cdp.Backend.Api.IntegrationTests/Services/Deployments/DeploymentServiceTest.cs
+++ b/Defra.Cdp.Backend.Api.IntegrationTests/Services/Deployments/DeploymentServiceTest.cs
@@ -177,6 +177,71 @@ public class DeploymentServiceTest : ServiceTest
     }
 
     [Fact]
+    public async Task UpdateDeploymentInstanceUsesVersionOrdering()
+    {
+        var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());
+        var service = new DeploymentsService(_mongoFactory, repositoryService, _userServiceBackendClient,
+            new NullLoggerFactory());
+
+        const string lambdaId = "ecs/12345";
+        var deployment = Deployment.FromRequest(new RequestedDeployment
+        {
+            Cpu = "1024",
+            Memory = "1024",
+            ConfigVersion = "e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e",
+            Environment = "test",
+            DeploymentId = Guid.NewGuid().ToString(),
+            InstanceCount = 2,
+            Service = "version-test-backend",
+            Version = "1.0.0",
+            User = new UserDetails { Id = "9999-9999-9999", DisplayName = "Test User" }
+        });
+
+        var ct = TestContext.Current.CancellationToken;
+        await service.RegisterDeployment(deployment, ct);
+        var linked = await service.LinkDeployment(deployment.CdpDeploymentId, lambdaId, ct);
+        Assert.True(linked);
+
+        var now = DateTime.UtcNow;
+        await service.UpdateInstance(deployment.CdpDeploymentId, "instance1",
+            new DeploymentInstanceStatus(DeploymentStatus.Running, now, 5), ct);
+
+        await service.UpdateInstance(deployment.CdpDeploymentId, "instance1",
+            new DeploymentInstanceStatus(DeploymentStatus.Pending, now.AddSeconds(1), 4), ct);
+
+        var afterStaleUpdate = await service.FindDeployment(deployment.CdpDeploymentId, ct);
+        Assert.NotNull(afterStaleUpdate);
+        Assert.Equal(DeploymentStatus.Running, afterStaleUpdate.Instances["instance1"].Status);
+        Assert.Equal(5L, afterStaleUpdate.Instances["instance1"].Version);
+
+        await service.UpdateInstance(deployment.CdpDeploymentId, "instance1",
+            new DeploymentInstanceStatus(DeploymentStatus.Pending, now.AddSeconds(2), 5), ct);
+
+        var afterEqualUpdate = await service.FindDeployment(deployment.CdpDeploymentId, ct);
+        Assert.NotNull(afterEqualUpdate);
+        Assert.Equal(DeploymentStatus.Pending, afterEqualUpdate.Instances["instance1"].Status);
+        Assert.Equal(5L, afterEqualUpdate.Instances["instance1"].Version);
+
+        await service.UpdateInstance(deployment.CdpDeploymentId, "instance1",
+            new DeploymentInstanceStatus(DeploymentStatus.Running, now.AddSeconds(3), 6), ct);
+
+        var afterNewerUpdate = await service.FindDeployment(deployment.CdpDeploymentId, ct);
+        Assert.NotNull(afterNewerUpdate);
+        Assert.Equal(DeploymentStatus.Running, afterNewerUpdate.Instances["instance1"].Status);
+        Assert.Equal(6L, afterNewerUpdate.Instances["instance1"].Version);
+
+        await service.UpdateInstance(deployment.CdpDeploymentId, "instance2",
+            new DeploymentInstanceStatus(DeploymentStatus.Pending, now.AddSeconds(4)), ct);
+        await service.UpdateInstance(deployment.CdpDeploymentId, "instance2",
+            new DeploymentInstanceStatus(DeploymentStatus.Running, now.AddSeconds(5), 1), ct);
+
+        var afterLegacyUpdate = await service.FindDeployment(deployment.CdpDeploymentId, ct);
+        Assert.NotNull(afterLegacyUpdate);
+        Assert.Equal(DeploymentStatus.Running, afterLegacyUpdate.Instances["instance2"].Status);
+        Assert.Equal(1L, afterLegacyUpdate.Instances["instance2"].Version);
+    }
+
+    [Fact]
     public async Task FindWhatsRunningWhereWithNoData()
     {
         var repositoryService = new EntitiesService(_mongoFactory, new NullLoggerFactory());

--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/TaskStateChangeEventHandlerTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/TaskStateChangeEventHandlerTests.cs
@@ -50,7 +50,8 @@ public class TaskStateChangeEventHandlerTests
             TaskDefinitionArn: "arn:aws:ecs:eu-west-2:506190012364:task-definition/cdp-example-node-backend:47",
             EcsSvcDeploymentId: null,
             StoppedReason: null,
-            StopCode: null
+            StopCode: null,
+            Version: 4
         ),
         "ecs-svc/6276605373259507742",
         "ecs-svc/6276605373259507742"
@@ -87,6 +88,11 @@ public class TaskStateChangeEventHandlerTests
 
         await deploymentsService.Received().FindDeploymentByLambdaId("ecs-svc/6276605373259507742", Arg.Any<CancellationToken>());
         await deploymentsService.DidNotReceiveWithAnyArgs().FindDeploymentByTaskArn(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await deploymentsService.Received().UpdateInstance(
+            deployment.CdpDeploymentId,
+            _testEvent.Detail.TaskArn,
+            Arg.Is<DeploymentInstanceStatus>(s => s.Status == DeploymentStatus.Running && s.Version == 4),
+            Arg.Any<CancellationToken>());
         await deploymentsService.Received().UpdateOverallTaskStatus(Arg.Any<Deployment>(), Arg.Any<CancellationToken>());
     }
 

--- a/Defra.Cdp.Backend.Api/Models/Deployment.cs
+++ b/Defra.Cdp.Backend.Api/Models/Deployment.cs
@@ -147,8 +147,10 @@ public class Audit
     public UserServiceUser? User { get; set; }
 }
 
-public class DeploymentInstanceStatus(string status, DateTime updated)
+public class DeploymentInstanceStatus(string status, DateTime updated, long? version = null)
 {
     public string Status { get; init; } = status;
     public DateTime Updated { get; init; } = updated;
+    [BsonIgnoreIfNull]
+    public long? Version { get; init; } = version;
 }

--- a/Defra.Cdp.Backend.Api/Models/EcsTaskStateChangeEvent.cs
+++ b/Defra.Cdp.Backend.Api/Models/EcsTaskStateChangeEvent.cs
@@ -59,7 +59,9 @@ public sealed record EcsEventDetail(
     [property: JsonPropertyName("stopCode")]
     string? StopCode = default,
     [property: JsonPropertyName("stoppedReason")]
-    string? StoppedReason = default
+    string? StoppedReason = default,
+    [property: JsonPropertyName("version")]
+    long? Version = default
 );
 
 public sealed record EcsEventCopy(

--- a/Defra.Cdp.Backend.Api/Services/Aws/Deployments/TaskStateChangeEventHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Aws/Deployments/TaskStateChangeEventHandler.cs
@@ -111,7 +111,8 @@ public class TaskStateChangeEventHandler(
             );
 
             await deploymentsService.UpdateInstance(deployment.CdpDeploymentId, instanceTaskId,
-                new DeploymentInstanceStatus(instanceStatus, ecsTaskStateChangeEvent.Timestamp), cancellationToken);
+                new DeploymentInstanceStatus(instanceStatus, ecsTaskStateChangeEvent.Timestamp,
+                    ecsTaskStateChangeEvent.Detail.Version), cancellationToken);
 
             await UpdateStatus(deployment.CdpDeploymentId, ecsTaskStateChangeEvent, cancellationToken);
         }

--- a/Defra.Cdp.Backend.Api/Services/Deployments/DeploymentsService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Deployments/DeploymentsService.cs
@@ -219,10 +219,29 @@ public class DeploymentsService(
         CancellationToken ct)
     {
         var fb = Builders<Deployment>.Filter;
-        var filter = fb.And(
-            fb.Eq(d => d.CdpDeploymentId, cdpDeploymentId));
+        var filter = fb.Eq(d => d.CdpDeploymentId, cdpDeploymentId);
+
+        if (instanceStatus.Version.HasValue)
+        {
+            // Only apply the write if we haven't stored a version yet, or the incoming version isn't stale.
+            // Guards against a redelivered/out-of-order ECS event overwriting a newer status.
+            var versionField = new StringFieldDefinition<Deployment, long?>($"instances.{instanceId}.version");
+            var versionFilter = fb.Or(
+                fb.Exists(versionField, false),
+                fb.Lte(versionField, instanceStatus.Version.Value)
+            );
+            filter = fb.And(filter, versionFilter);
+        }
+
         var update = Builders<Deployment>.Update.Set(d => d.Instances[instanceId], instanceStatus);
-        await Collection.UpdateOneAsync(filter, update, cancellationToken: ct);
+        var result = await Collection.UpdateOneAsync(filter, update, cancellationToken: ct);
+
+        if (instanceStatus.Version.HasValue && result.MatchedCount == 0)
+        {
+            Logger.LogInformation(
+                "Skipped stale instance update for {CdpDeploymentId}/{InstanceId}, incoming version {Version}",
+                cdpDeploymentId, instanceId, instanceStatus.Version.Value);
+        }
     }
 
     public async Task<Deployment?> FindDeploymentByTaskArn(string taskArn, CancellationToken ct)


### PR DESCRIPTION
- Persists ECS detail.version (per-task-ARN incrementing sequence number) on each deployment instance, alongside status/updated.
- DeploymentsService.UpdateInstance now only applies a write when there's no stored version yet or the incoming version isn't stale, preventing a redelivered/out-of-order SQS message (e.g. after a portal-backend redeploy) from overwriting a newer status back to pending.
- EcsEventDetail.Version is optional so old messages/records without it deserialize fine and fall back to today's unconditional-write behavior.
- Adds integration coverage for stale, equal, missing-then-versioned, and newer version scenarios, plus a unit test asserting the version is threaded through from the handler.

Example deploymentsV2 model:
```
    "instances": {
      "arn:aws:ecs:eu-west-2:000000000000:task/dev-ecs-public/2598afa8-8ec0-458a-ab94-b40bc133567a": {
        "status": "running",
        "updated": {"$date": "2026-08-04T14:25:24.683Z"},
        "version": 5
      }
    },
```