### PR TITLE
CORE-3747: Remove dead GH-synced fields

### DIFF
--- a/Defra.Cdp.Backend.Api.IntegrationTests/Services/Entities/EntitiesServiceTest.cs
+++ b/Defra.Cdp.Backend.Api.IntegrationTests/Services/Entities/EntitiesServiceTest.cs
@@ -98,8 +98,6 @@ public class EntitiesServiceTest(MongoContainerFixture fixture) : MongoTestSuppo
     {
         Id = "foo",
         Teams = [new RepositoryTeam("foo-team", "1234", "foo-team")],
-        IsArchived = false,
-        IsTemplate = false,
-        IsPrivate = false
+        IsArchived = false
     };
 }

--- a/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/PopulateGithubRepositoriesTest.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/PopulateGithubRepositoriesTest.cs
@@ -17,10 +17,10 @@ public class PopulateGithubRepositoriesTest
                     new RepositoryTeam("cdp-platform", "platform-team-id", "Platform"),
                     [
                         new RepositoryNode("repo1", topics, "desc1", new PrimaryLanguage("Javascript"),
-                            "https://url1", false, false, true, dateTimeNow),
+                            "https://url1", false, dateTimeNow),
 
                         new RepositoryNode("repo3", topics, "desc3", new PrimaryLanguage("Java"),
-                            "https://url3", false, true, false, dateTimeNow)
+                            "https://url3", false, dateTimeNow)
                     ]
                 },
                 {
@@ -28,9 +28,9 @@ public class PopulateGithubRepositoriesTest
                     [
 
                         new RepositoryNode("repo2", topics, "desc2", new PrimaryLanguage("C#"),
-                            "https://url2", false, true, true, dateTimeNow),
+                            "https://url2", false, dateTimeNow),
                         new RepositoryNode("repo3", topics, "desc3", new PrimaryLanguage("Java"),
-                            "https://url3", false, true, false, dateTimeNow)
+                            "https://url3", false, dateTimeNow)
                     ]
                 }
             });
@@ -45,8 +45,6 @@ public class PopulateGithubRepositoriesTest
                 CreatedAt = dateTimeNow,
                 Description = "desc1",
                 IsArchived = false,
-                IsPrivate = true,
-                IsTemplate = false,
                 PrimaryLanguage = "Javascript",
                 Url = "https://url1",
                 Teams = [new RepositoryTeam("cdp-platform", "platform-team-id", "Platform")]
@@ -58,8 +56,6 @@ public class PopulateGithubRepositoriesTest
                 CreatedAt = dateTimeNow,
                 Description = "desc2",
                 IsArchived = false,
-                IsPrivate = true,
-                IsTemplate = true,
                 PrimaryLanguage = "C#",
                 Url = "https://url2",
                 Teams = [new RepositoryTeam("fisheries", "fisheries-team-id", "Fisheries")]
@@ -71,8 +67,6 @@ public class PopulateGithubRepositoriesTest
                 CreatedAt = dateTimeNow,
                 Description = "desc3",
                 IsArchived = false,
-                IsPrivate = false,
-                IsTemplate = true,
                 PrimaryLanguage = "Java",
                 Url = "https://url3",
                 Teams =

--- a/Defra.Cdp.Backend.Api/Models/Repository.cs
+++ b/Defra.Cdp.Backend.Api/Models/Repository.cs
@@ -5,6 +5,7 @@ namespace Defra.Cdp.Backend.Api.Models;
 
 public record RepositoryTeam(string Github, string? TeamId, string? Name);
 
+[BsonIgnoreExtraElements]
 public sealed class Repository : IEquatable<Repository>
 {
     [BsonId]
@@ -18,10 +19,6 @@ public sealed class Repository : IEquatable<Repository>
     public string Url { get; init; } = null!;
 
     public bool IsArchived { get; init; }
-
-    public bool IsTemplate { get; init; }
-
-    public bool IsPrivate { get; init; }
 
     public DateTimeOffset CreatedAt { get; init; }
 
@@ -37,8 +34,6 @@ public sealed class Repository : IEquatable<Repository>
                PrimaryLanguage == other.PrimaryLanguage &&
                Url == other.Url &&
                IsArchived == other.IsArchived &&
-               IsTemplate == other.IsTemplate &&
-               IsPrivate == other.IsPrivate &&
                CreatedAt == other.CreatedAt &&
                Teams.ToHashSet().SetEquals(other.Teams.ToHashSet());
     }

--- a/Defra.Cdp.Backend.Api/Services/Github/RepositoryService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Github/RepositoryService.cs
@@ -51,25 +51,6 @@ public class RepositoryService(
         return repository;
     }
 
-    public async Task<List<Repository>> AllRepositories(bool excludeTemplates, CancellationToken cancellationToken)
-    {
-        var builder = Builders<Repository>.Filter;
-        var filter = builder.Empty;
-        var withoutTemplatesFilter = builder.Eq(r => r.IsTemplate, false);
-        var withCdpTopicFilter = builder.Where(r => r.Topics.Contains("cdp"));
-
-        var findDefinition = excludeTemplates
-            ? withoutTemplatesFilter
-            : filter;
-
-        var repositories =
-            await Collection
-                .Find(findDefinition & withCdpTopicFilter)
-                .SortBy(r => r.Id)
-                .ToListAsync(cancellationToken);
-        return repositories;
-    }
-
     public async Task DeleteUnknownRepos(IEnumerable<string> knownReposIds, CancellationToken cancellationToken)
     {
         var excludingIdsList = knownReposIds.ToList();
@@ -123,7 +104,6 @@ public class RepositoryService(
         var createdAtIndex = new CreateIndexModel<Repository>(builder.Ascending(r => r.CreatedAt));
         var teamsIndex = new CreateIndexModel<Repository>(builder.Ascending(r => r.Teams));
         var languageIndex = new CreateIndexModel<Repository>(builder.Ascending(r => r.PrimaryLanguage));
-        var isTemplateIndex = new CreateIndexModel<Repository>(builder.Ascending(r => r.IsTemplate));
         var isArchivedIndex = new CreateIndexModel<Repository>(builder.Ascending(r => r.IsArchived));
         var teamIdIndex = new CreateIndexModel<Repository>(builder.Ascending(r => r.Teams.Select(t => t.TeamId)),
             new CreateIndexOptions { Sparse = true });
@@ -133,7 +113,6 @@ public class RepositoryService(
             createdAtIndex,
             teamsIndex,
             languageIndex,
-            isTemplateIndex,
             isArchivedIndex,
             teamIdIndex
         ];

--- a/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/GraphQlQueryResponse.cs
+++ b/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/GraphQlQueryResponse.cs
@@ -46,8 +46,6 @@ public record RepositoryNode(
     PrimaryLanguage? primaryLanguage,
     string url,
     bool isArchived,
-    bool isTemplate,
-    bool isPrivate,
     DateTimeOffset createdAt
 );
 

--- a/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/PopulateGithubRepositories.cs
+++ b/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/PopulateGithubRepositories.cs
@@ -92,8 +92,6 @@ public sealed class PopulateGithubRepositories(
                         CreatedAt = repo.createdAt,
                         Description = repo.description,
                         IsArchived = repo.isArchived,
-                        IsPrivate = repo.isPrivate,
-                        IsTemplate = repo.isTemplate,
                         Url = repo.url,
                         PrimaryLanguage = repo.primaryLanguage?.name ?? "Unknown",
                         Teams = [],
@@ -223,8 +221,6 @@ public sealed class PopulateGithubRepositories(
                                   },
                                   url,
                                   isArchived,
-                                  isTemplate,
-                                  isPrivate,
                                   createdAt
                                 }
                               }

--- a/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/RepositoryCreationPoller.cs
+++ b/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/RepositoryCreationPoller.cs
@@ -129,8 +129,6 @@ public sealed class RepositoryCreationPoller(
                     CreatedAt = repo.createdAt,
                     Description = repo.description,
                     IsArchived = repo.isArchived,
-                    IsPrivate = repo.isPrivate,
-                    IsTemplate = repo.isTemplate,
                     Url = repo.url,
                     PrimaryLanguage = repo.primaryLanguage?.name ?? "Unknown",
                     Teams = teams,
@@ -187,8 +185,6 @@ public sealed class RepositoryCreationPoller(
         description
         url
         isArchived
-        isTemplate
-        isPrivate
         createdAt
         primaryLanguage {{
           name


### PR DESCRIPTION
This is part 1 of decoupling from githhub.

- [ ] **remove dead GH sync fields, keep IsArchived**
- [ ] flatten the org-wide repository query
- [ ] Decouple GH Teams sync microservices/test-suites
- [ ] Investigate what to do with libraries: topic driven query or leave GH teams/topics sync
- [ ] Investigate what to do with templates: there are two sources: cdp-self-service-ops hardcodewd and cdp-portal-backed topics driven

---

Remove `IsPrivate`/`IsTemplate` from the model, GraphQL queries/responses, sync jobs, and the dead `AllRepositories` method that referenced `IsTemplate`.

Keep `IsArchived` as we will need it in future