### PR TITLE
CORE-3747: Flatten GitHub repo sync and use Entity ownership

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Defra.Cdp.Backend.Api.Tests.csproj
+++ b/Defra.Cdp.Backend.Api.Tests/Defra.Cdp.Backend.Api.Tests.csproj
@@ -78,6 +78,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Services\Github\ScheduledTasks\Fixtures\*.json">
+      <Link>Fixtures\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Defra.Cdp.Backend.Api\Defra.Cdp.Backend.Api.csproj" />
   </ItemGroup>
 

--- a/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/Fixtures/github-search-page-1.json
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/Fixtures/github-search-page-1.json
@@ -1,0 +1,177 @@
+{
+  "data": {
+    "search": {
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "Y3Vyc29yOjIw"
+      },
+      "nodes": [
+        {
+          "name": "cdp-dotnet-backend-template",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "backend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "dotnet"
+                }
+              },
+              {
+                "topic": {
+                  "name": "template"
+                }
+              }
+            ]
+          },
+          "description": "C# ASP.NET Minimial API template with MongoDB, FluentValidation, Swagger and Serilog logging",
+          "primaryLanguage": {
+            "name": "C#"
+          },
+          "url": "https://github.com/DEFRA/cdp-dotnet-backend-template",
+          "isArchived": false,
+          "createdAt": "2023-08-24T07:08:56Z"
+        },
+        {
+          "name": "grants-ui",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "frontend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "node"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service grants-ui",
+          "primaryLanguage": {
+            "name": "JavaScript"
+          },
+          "url": "https://github.com/DEFRA/grants-ui",
+          "isArchived": false,
+          "createdAt": "2025-03-19T10:08:04Z"
+        },
+        {
+          "name": "trade-imports-data-api",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "backend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "dotnet"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service trade-imports-data-api",
+          "primaryLanguage": {
+            "name": "C#"
+          },
+          "url": "https://github.com/DEFRA/trade-imports-data-api",
+          "isArchived": false,
+          "createdAt": "2025-04-01T15:11:37Z"
+        },
+        {
+          "name": "forms-runner",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "frontend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service forms-runner",
+          "primaryLanguage": {
+            "name": "JavaScript"
+          },
+          "url": "https://github.com/DEFRA/forms-runner",
+          "isArchived": false,
+          "createdAt": "2023-11-08T14:45:21Z"
+        },
+        {
+          "name": "cdp-node-backend-template",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "template"
+                }
+              },
+              {
+                "topic": {
+                  "name": "backend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "node"
+                }
+              }
+            ]
+          },
+          "description": "Core delivery platform Node.js Backend Template",
+          "primaryLanguage": {
+            "name": "JavaScript"
+          },
+          "url": "https://github.com/DEFRA/cdp-node-backend-template",
+          "isArchived": false,
+          "createdAt": "2023-06-20T12:10:50Z"
+        }
+      ]
+    }
+  }
+}

--- a/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/Fixtures/github-search-page-2.json
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/Fixtures/github-search-page-2.json
@@ -1,0 +1,172 @@
+{
+  "data": {
+    "search": {
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "Y3Vyc29yOjQw"
+      },
+      "nodes": [
+        {
+          "name": "marine-licensing-backend-demo",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "backend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "node"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service marine-licensing-backend-demo",
+          "primaryLanguage": {
+            "name": "JavaScript"
+          },
+          "url": "https://github.com/DEFRA/marine-licensing-backend-demo",
+          "isArchived": true,
+          "createdAt": "2024-03-14T13:53:13Z"
+        },
+        {
+          "name": "ai-model-test",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "backend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "python"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service ai-model-test",
+          "primaryLanguage": {
+            "name": "Python"
+          },
+          "url": "https://github.com/DEFRA/ai-model-test",
+          "isArchived": false,
+          "createdAt": "2025-03-20T16:39:21Z"
+        },
+        {
+          "name": "ahwr-public-user-ui",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "frontend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "node"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service ahwr-public-user-ui",
+          "primaryLanguage": {
+            "name": "JavaScript"
+          },
+          "url": "https://github.com/DEFRA/ahwr-public-user-ui",
+          "isArchived": false,
+          "createdAt": "2025-09-30T13:43:09Z"
+        },
+        {
+          "name": "disinfectant-frontend",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "frontend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "node"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service disinfectant-frontend",
+          "primaryLanguage": {
+            "name": "JavaScript"
+          },
+          "url": "https://github.com/DEFRA/disinfectant-frontend",
+          "isArchived": false,
+          "createdAt": "2024-06-28T10:15:54Z"
+        },
+        {
+          "name": "nrf-library",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "repository"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for nrf-library",
+          "primaryLanguage": {
+            "name": "JavaScript"
+          },
+          "url": "https://github.com/DEFRA/nrf-library",
+          "isArchived": false,
+          "createdAt": "2026-04-28T14:07:53Z"
+        }
+      ]
+    }
+  }
+}

--- a/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/Fixtures/github-search-page-3.json
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/Fixtures/github-search-page-3.json
@@ -1,0 +1,172 @@
+{
+  "data": {
+    "search": {
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "Y3Vyc29yOjYw"
+      },
+      "nodes": [
+        {
+          "name": "epr-backend",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "backend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "node"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service epr-backend",
+          "primaryLanguage": {
+            "name": "JavaScript"
+          },
+          "url": "https://github.com/DEFRA/epr-backend",
+          "isArchived": false,
+          "createdAt": "2025-04-10T09:58:41Z"
+        },
+        {
+          "name": "trade-imports-processor",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "backend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "dotnet"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service trade-imports-processor",
+          "primaryLanguage": {
+            "name": "C#"
+          },
+          "url": "https://github.com/DEFRA/trade-imports-processor",
+          "isArchived": false,
+          "createdAt": "2025-04-01T15:13:45Z"
+        },
+        {
+          "name": "pha-import-notifications",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "backend"
+                }
+              },
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "dotnet"
+                }
+              },
+              {
+                "topic": {
+                  "name": "service"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for service pha-import-notifications",
+          "primaryLanguage": {
+            "name": "C#"
+          },
+          "url": "https://github.com/DEFRA/pha-import-notifications",
+          "isArchived": false,
+          "createdAt": "2024-10-29T11:04:22Z"
+        },
+        {
+          "name": "cdp-node-prototype-template",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "repository"
+                }
+              },
+              {
+                "topic": {
+                  "name": "template"
+                }
+              },
+              {
+                "topic": {
+                  "name": "prototype"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for cdp-node-prototype-template",
+          "primaryLanguage": {
+            "name": "Dockerfile"
+          },
+          "url": "https://github.com/DEFRA/cdp-node-prototype-template",
+          "isArchived": false,
+          "createdAt": "2025-07-18T12:04:13Z"
+        },
+        {
+          "name": "grant-config-woodland",
+          "repositoryTopics": {
+            "nodes": [
+              {
+                "topic": {
+                  "name": "cdp"
+                }
+              },
+              {
+                "topic": {
+                  "name": "repository"
+                }
+              }
+            ]
+          },
+          "description": "Git repository for grant-config-woodland",
+          "primaryLanguage": {
+            "name": "Shell"
+          },
+          "url": "https://github.com/DEFRA/grant-config-woodland",
+          "isArchived": true,
+          "createdAt": "2026-03-31T15:10:51Z"
+        }
+      ]
+    }
+  }
+}

--- a/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/PopulateGithubRepositoriesTest.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Github/ScheduledTasks/PopulateGithubRepositoriesTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Services.Github.ScheduledTasks;
 
@@ -5,32 +6,75 @@ namespace Defra.Cdp.Backend.Api.Tests.Services.Github.ScheduledTasks;
 
 public class PopulateGithubRepositoriesTest
 {
+    // GitHub's GraphQL API can return null entries in paginated `nodes` arrays.
+    // We now filter these before building repositories.
     [Fact]
-    public void AddMultipleTeamsToRepositories()
+    public void RemoveNullRepositoryNodesFiltersNullEntries()
+    {
+        var dateTimeNow = DateTimeOffset.Now;
+        var nodes = new List<RepositoryNode?>
+        {
+            null,
+            new RepositoryNode("repo1", Topics.CreateMockTopics(), "desc1", null, "url1", false, dateTimeNow)
+        };
+
+        var githubRepositoryNodes = PopulateGithubRepositories.RemoveNullRepositoryNodes(nodes);
+
+        Assert.Single(githubRepositoryNodes);
+        Assert.Equal("repo1", githubRepositoryNodes[0].name);
+    }
+
+    [Fact]
+    public void JsonDeserializationProducesNullListEntryForNullNode()
+    {
+        const string json = """
+        {
+          "data": {
+            "search": {
+              "pageInfo": { "hasNextPage": false, "endCursor": "abc" },
+              "nodes": [
+                null,
+                { "name": "repo1", "repositoryTopics": { "nodes": [] }, "description": "d", "primaryLanguage": null, "url": "u", "isArchived": false, "createdAt": "2024-01-01T00:00:00Z" }
+              ]
+            }
+          }
+        }
+        """;
+
+        var result = JsonSerializer.Deserialize<SearchRepoQueryResponse>(json);
+        var nodes = result!.data!.search.nodes.ToList();
+
+        Assert.Equal(2, nodes.Count);
+        Assert.Null(nodes[0]);
+        Assert.NotNull(nodes[1]);
+        Assert.Equal("repo1", nodes[1]!.name);
+    }
+
+    [Fact]
+    public void BuildRepositoriesUsesEntityTeamsForEntityBackedRepos()
     {
         var topics = Topics.CreateMockTopics();
         var dateTimeNow = DateTimeOffset.Now;
-        var repositories = PopulateGithubRepositories.GroupRepositoriesByTeam(
-            new Dictionary<RepositoryTeam, List<RepositoryNode>>
+        var repositories = PopulateGithubRepositories.BuildRepositories(
+            [
+                new RepositoryNode("repo1", topics, "desc1", new PrimaryLanguage("Javascript"),
+                    "https://url1", false, dateTimeNow),
+                new RepositoryNode("repo2", topics, "desc2", new PrimaryLanguage("C#"),
+                    "https://url2", false, dateTimeNow)
+            ],
+            new HashSet<string>(["repo1"], StringComparer.OrdinalIgnoreCase),
+            new Dictionary<string, List<RepositoryTeam>>(StringComparer.OrdinalIgnoreCase)
             {
                 {
-                    new RepositoryTeam("cdp-platform", "platform-team-id", "Platform"),
+                    "repo1",
                     [
-                        new RepositoryNode("repo1", topics, "desc1", new PrimaryLanguage("Javascript"),
-                            "https://url1", false, dateTimeNow),
-
-                        new RepositoryNode("repo3", topics, "desc3", new PrimaryLanguage("Java"),
-                            "https://url3", false, dateTimeNow)
+                        new RepositoryTeam("cdp-platform", "platform-team-id", "Platform")
                     ]
                 },
                 {
-                    new RepositoryTeam("fisheries", "fisheries-team-id", "Fisheries"),
+                    "repo2",
                     [
-
-                        new RepositoryNode("repo2", topics, "desc2", new PrimaryLanguage("C#"),
-                            "https://url2", false, dateTimeNow),
-                        new RepositoryNode("repo3", topics, "desc3", new PrimaryLanguage("Java"),
-                            "https://url3", false, dateTimeNow)
+                        new RepositoryTeam("fisheries", "fisheries-team-id", "Fisheries")
                     ]
                 }
             });
@@ -47,7 +91,7 @@ public class PopulateGithubRepositoriesTest
                 IsArchived = false,
                 PrimaryLanguage = "Javascript",
                 Url = "https://url1",
-                Teams = [new RepositoryTeam("cdp-platform", "platform-team-id", "Platform")]
+                Teams = []
             },
             new()
             {
@@ -59,24 +103,156 @@ public class PopulateGithubRepositoriesTest
                 PrimaryLanguage = "C#",
                 Url = "https://url2",
                 Teams = [new RepositoryTeam("fisheries", "fisheries-team-id", "Fisheries")]
-            },
-            new()
-            {
-                Id = "repo3",
-                Topics = topicNames,
-                CreatedAt = dateTimeNow,
-                Description = "desc3",
-                IsArchived = false,
-                PrimaryLanguage = "Java",
-                Url = "https://url3",
-                Teams =
-                [
-                    new RepositoryTeam("cdp-platform", "platform-team-id", "Platform"),
-                    new RepositoryTeam("fisheries", "fisheries-team-id", "Fisheries")
-                ]
             }
         };
         
         Assert.Equivalent(expected, repositories);
+    }
+
+    [Fact]
+    public void BuildRepositoriesDoesNotFailWhenNodesContainNullEntries()
+    {
+        var dateTimeNow = DateTimeOffset.Now;
+        var topics = Topics.CreateMockTopics();
+        var repositoryNodes = new List<RepositoryNode?>
+        {
+            null,
+            new RepositoryNode(
+                "repo1",
+                topics,
+                "desc1",
+                new PrimaryLanguage("Javascript"),
+                "https://url1",
+                false,
+                dateTimeNow
+            )
+        };
+
+        var githubRepositoryNodes = PopulateGithubRepositories.RemoveNullRepositoryNodes(repositoryNodes);
+        var githubTeamsByRepoName = new Dictionary<string, List<RepositoryTeam>>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "repo1", [new RepositoryTeam("cdp-platform", "platform-team-id", "Platform")] }
+        };
+
+        var ex = Record.Exception(() =>
+            PopulateGithubRepositories.BuildRepositories(githubRepositoryNodes, new HashSet<string>(), githubTeamsByRepoName)
+        );
+
+        Assert.Null(ex);
+
+        var repositories =
+            PopulateGithubRepositories.BuildRepositories(githubRepositoryNodes, new HashSet<string>(), githubTeamsByRepoName);
+        Assert.Single(repositories);
+        Assert.Equal("repo1", repositories[0].Id);
+        Assert.Single(repositories[0].Teams);
+        Assert.Equal("platform-team-id", repositories[0].Teams[0].TeamId);
+    }
+
+    [Fact]
+    public void BuildRepositoriesFromRealGithubSearchFixtures()
+    {
+        var fixtureNames = new[]
+        {
+            "github-search-page-1.json",
+            "github-search-page-2.json",
+            "github-search-page-3.json"
+        };
+
+        var allNodes = fixtureNames
+            .Select(ReadFixture)
+            .Select(fixture => JsonSerializer.Deserialize<SearchRepoQueryResponse>(fixture))
+            .SelectMany(response => response!.data!.search.nodes)
+            .ToList();
+
+        var githubRepositoryNodes = PopulateGithubRepositories.RemoveNullRepositoryNodes(allNodes);
+        var repositories = PopulateGithubRepositories.BuildRepositories(
+            githubRepositoryNodes,
+            new HashSet<string>(),
+            new Dictionary<string, List<RepositoryTeam>>()
+        );
+
+        var expected = new List<Repository>
+        {
+            Expected("cdp-dotnet-backend-template",
+                "C# ASP.NET Minimial API template with MongoDB, FluentValidation, Swagger and Serilog logging",
+                "C#", "https://github.com/DEFRA/cdp-dotnet-backend-template", false,
+                "2023-08-24T07:08:56Z", ["backend", "cdp", "dotnet", "template"]),
+            Expected("grants-ui", "Git repository for service grants-ui", "JavaScript",
+                "https://github.com/DEFRA/grants-ui", false, "2025-03-19T10:08:04Z",
+                ["cdp", "frontend", "node", "service"]),
+            Expected("trade-imports-data-api", "Git repository for service trade-imports-data-api", "C#",
+                "https://github.com/DEFRA/trade-imports-data-api", false, "2025-04-01T15:11:37Z",
+                ["backend", "cdp", "dotnet", "service"]),
+            Expected("forms-runner", "Git repository for service forms-runner", "JavaScript",
+                "https://github.com/DEFRA/forms-runner", false, "2023-11-08T14:45:21Z",
+                ["cdp", "frontend", "service"]),
+            Expected("cdp-node-backend-template", "Core delivery platform Node.js Backend Template",
+                "JavaScript", "https://github.com/DEFRA/cdp-node-backend-template", false,
+                "2023-06-20T12:10:50Z", ["cdp", "template", "backend", "node"]),
+            Expected("marine-licensing-backend-demo",
+                "Git repository for service marine-licensing-backend-demo", "JavaScript",
+                "https://github.com/DEFRA/marine-licensing-backend-demo", true, "2024-03-14T13:53:13Z",
+                ["backend", "cdp", "node", "service"]),
+            Expected("ai-model-test", "Git repository for service ai-model-test", "Python",
+                "https://github.com/DEFRA/ai-model-test", false, "2025-03-20T16:39:21Z",
+                ["backend", "cdp", "python", "service"]),
+            Expected("ahwr-public-user-ui", "Git repository for service ahwr-public-user-ui", "JavaScript",
+                "https://github.com/DEFRA/ahwr-public-user-ui", false, "2025-09-30T13:43:09Z",
+                ["cdp", "frontend", "node", "service"]),
+            Expected("disinfectant-frontend", "Git repository for service disinfectant-frontend",
+                "JavaScript", "https://github.com/DEFRA/disinfectant-frontend", false,
+                "2024-06-28T10:15:54Z", ["cdp", "frontend", "node", "service"]),
+            Expected("nrf-library", "Git repository for nrf-library", "JavaScript",
+                "https://github.com/DEFRA/nrf-library", false, "2026-04-28T14:07:53Z",
+                ["cdp", "repository"]),
+            Expected("epr-backend", "Git repository for service epr-backend", "JavaScript",
+                "https://github.com/DEFRA/epr-backend", false, "2025-04-10T09:58:41Z",
+                ["backend", "cdp", "node", "service"]),
+            Expected("trade-imports-processor", "Git repository for service trade-imports-processor",
+                "C#", "https://github.com/DEFRA/trade-imports-processor", false,
+                "2025-04-01T15:13:45Z", ["backend", "cdp", "dotnet", "service"]),
+            Expected("pha-import-notifications", "Git repository for service pha-import-notifications",
+                "C#", "https://github.com/DEFRA/pha-import-notifications", false,
+                "2024-10-29T11:04:22Z", ["backend", "cdp", "dotnet", "service"]),
+            Expected("cdp-node-prototype-template", "Git repository for cdp-node-prototype-template",
+                "Dockerfile", "https://github.com/DEFRA/cdp-node-prototype-template", false,
+                "2025-07-18T12:04:13Z", ["cdp", "repository", "template", "prototype"]),
+            Expected("grant-config-woodland", "Git repository for grant-config-woodland", "Shell",
+                "https://github.com/DEFRA/grant-config-woodland", true, "2026-03-31T15:10:51Z",
+                ["cdp", "repository"])
+        };
+
+        Assert.Equivalent(expected, repositories);
+    }
+
+    private static Repository Expected(
+        string id,
+        string description,
+        string primaryLanguage,
+        string url,
+        bool isArchived,
+        string createdAt,
+        string[] topics) =>
+        new()
+        {
+            Id = id,
+            Description = description,
+            PrimaryLanguage = primaryLanguage,
+            Url = url,
+            IsArchived = isArchived,
+            CreatedAt = DateTimeOffset.Parse(createdAt),
+            Teams = [],
+            Topics = topics
+        };
+
+    private static string ReadFixture(string fileName)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", fileName);
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Could not locate fixture file '{path}'");
+        }
+
+        return File.ReadAllText(path);
     }
 }

--- a/Defra.Cdp.Backend.Api/Defra.Cdp.Backend.Api.csproj
+++ b/Defra.Cdp.Backend.Api/Defra.Cdp.Backend.Api.csproj
@@ -53,4 +53,8 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="_lukasz_docs\example\" />
+  </ItemGroup>
+
 </Project>

--- a/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/GraphQlQueryResponse.cs
+++ b/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/GraphQlQueryResponse.cs
@@ -2,29 +2,20 @@ namespace Defra.Cdp.Backend.Api.Services.Github.ScheduledTasks;
 
 public record PageInfo(
     bool hasNextPage,
-    string endCursor
+    string? endCursor
 );
 
-public record RepoQueryResponse(
-    Data? data
+public record SearchRepoQueryResponse(
+    SearchData? data
 );
 
-public record Data(
-    Organization organization
+public record SearchData(
+    SearchResults search
 );
 
-public record Organization(
-    string id,
-    Team? team
-);
-
-public record Team(
-    Repositories repositories
-);
-
-public record Repositories(
+public record SearchResults(
     PageInfo pageInfo,
-    IEnumerable<RepositoryNode> nodes
+    IEnumerable<RepositoryNode?> nodes
 );
 
 public record RepositoryTopics(
@@ -51,4 +42,8 @@ public record RepositoryNode(
 
 public record PrimaryLanguage(
     string name
+);
+
+public record GithubTeamSummary(
+    string slug
 );

--- a/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/PopulateGithubRepositories.cs
+++ b/Defra.Cdp.Backend.Api/Services/Github/ScheduledTasks/PopulateGithubRepositories.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Mongo;
+using Defra.Cdp.Backend.Api.Services.Entities;
 using Defra.Cdp.Backend.Api.Services.Teams;
 using Microsoft.AspNetCore.HeaderPropagation;
 using Microsoft.Extensions.Primitives;
@@ -15,6 +16,7 @@ public sealed class PopulateGithubRepositories(
     IConfiguration configuration,
     ILoggerFactory loggerFactory,
     IRepositoryService repositoryService,
+    IEntitiesService entitiesService,
     IMongoLock mongoLock,
     IHttpClientFactory clientFactory,
     ITeamsService teamsService,
@@ -26,9 +28,8 @@ public sealed class PopulateGithubRepositories(
 
     private readonly HttpClient _client = clientFactory.CreateClient("GitHubClient");
     private readonly string _githubApiUrl = $"{configuration.GetValue<string>("Github:ApiUrl")!}/graphql";
-
-
     private readonly string _githubOrgName = configuration.GetValue<string>("Github:Organisation")!;
+    private readonly string _githubRestApiUrl = configuration.GetValue<string>("Github:ApiUrl")!;
 
     private readonly ILogger<PopulateGithubRepositories> _logger =
         loggerFactory.CreateLogger<PopulateGithubRepositories>();
@@ -36,7 +37,6 @@ public sealed class PopulateGithubRepositories(
     public async Task Execute(IJobExecutionContext context)
     {
         if (await mongoLock.Lock(LockName, TimeSpan.FromSeconds(60)))
-        {
             try
             {
                 // Workaround mentioned in https://github.com/alefranz/HeaderPropagation/issues/5
@@ -52,7 +52,6 @@ public sealed class PopulateGithubRepositories(
             {
                 await mongoLock.Unlock(LockName);
             }
-        }
     }
 
     private async Task RepopulateGithubRepos(IJobExecutionContext context)
@@ -60,175 +59,226 @@ public sealed class PopulateGithubRepositories(
         _logger.LogInformation("Repopulating Github repositories");
         var cancellationToken = context.CancellationToken;
 
-        var teams = await GetRepositoryTeams(cancellationToken);
+        var cdpTeamsByGithubSlug = await GetRepositoryTeams(cancellationToken);
+        var entityNames = await GetEntityNames(cancellationToken);
 
         var token = await githubCredentialAndConnectionFactory.GetToken(cancellationToken);
         if (token is null) throw new ArgumentNullException("token", "Installation token cannot be null");
         _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        var repositoryNodesByTeam = await GetReposFromGithubByTeam(teams ?? [], cancellationToken);
+        var githubRepositoryNodes = await GetReposFromGithub(cancellationToken);
+        var githubTeamsByRepoName = await GetGithubTeamsByRepoName(
+            githubRepositoryNodes,
+            entityNames,
+            cdpTeamsByGithubSlug,
+            cancellationToken
+        );
 
-        var repositories = GroupRepositoriesByTeam(repositoryNodesByTeam);
+        var repositories = BuildRepositories(githubRepositoryNodes, entityNames, githubTeamsByRepoName);
 
         await repositoryService.UpsertMany(repositories, cancellationToken);
         await repositoryService.DeleteUnknownRepos(repositories.Select(r => r.Id), cancellationToken);
         _logger.LogInformation("Successfully repopulated repositories and team information");
     }
 
-    public static List<Repository> GroupRepositoriesByTeam(
-        Dictionary<RepositoryTeam, List<RepositoryNode>> repositoryNodesByTeam)
+    public static List<Repository> BuildRepositories(
+        IEnumerable<RepositoryNode> githubRepositoryNodes,
+        HashSet<string> entityNames,
+        Dictionary<string, List<RepositoryTeam>> githubTeamsByRepoName)
     {
-        var repoMap = new Dictionary<string, Repository>();
-
-        foreach (var (team, repos) in repositoryNodesByTeam)
-        {
-            foreach (var repo in repos)
+        return githubRepositoryNodes
+            .Select(repo =>
             {
-                if (!repoMap.TryGetValue(repo.name, out var existingRepo))
-                {
-                    existingRepo = new Repository
-                    {
-                        Id = repo.name,
-                        CreatedAt = repo.createdAt,
-                        Description = repo.description,
-                        IsArchived = repo.isArchived,
-                        Url = repo.url,
-                        PrimaryLanguage = repo.primaryLanguage?.name ?? "Unknown",
-                        Teams = [],
-                        Topics = repo.repositoryTopics.nodes.Select(t => t.topic.name)
-                    };
-                    
-                    repoMap[repo.name] = existingRepo;
-                }
+                var teams = entityNames.Contains(repo.name)
+                    ? [] // Entity is the source of truth for services/test suites; skip storing GitHub ownership on the repo
+                    : githubTeamsByRepoName.GetValueOrDefault(repo.name) ?? [];
 
-                if (!existingRepo.Teams.Contains(team))
+                return new Repository
                 {
-                    existingRepo.Teams.Add(team);
-                }
-            }
-        }
-
-        return repoMap.Values.ToList();
+                    Id = repo.name,
+                    CreatedAt = repo.createdAt,
+                    Description = repo.description,
+                    IsArchived = repo.isArchived,
+                    Url = repo.url,
+                    PrimaryLanguage = repo.primaryLanguage?.name ?? "Unknown",
+                    Teams = teams,
+                    Topics = repo.repositoryTopics.nodes.Select(t => t.topic.name)
+                };
+            })
+            .ToList();
     }
 
-    private async Task<List<RepositoryTeam>> GetRepositoryTeams(CancellationToken cancellationToken)
+    public static List<RepositoryNode> RemoveNullRepositoryNodes(IEnumerable<RepositoryNode?> githubRepositoryNodes)
+    {
+        return githubRepositoryNodes.Where(node => node is not null).Select(node => node!).ToList();
+    }
+
+    private async Task<HashSet<string>> GetEntityNames(CancellationToken cancellationToken)
+    {
+        var entities = await entitiesService.GetEntityIds(new EntityMatcher(), cancellationToken);
+        return entities.ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    // Entity-backed services/test-suites already get ownership from Entity.Teams, so we skip
+    // GitHub team lookup for them. For repos with no Entity (templates, libraries, and other
+    // CDP-tagged repos), GitHub remains the only ownership source — fetch teams for those only.
+    private async Task<Dictionary<string, List<RepositoryTeam>>> GetGithubTeamsByRepoName(
+        IEnumerable<RepositoryNode> githubRepositoryNodes,
+        HashSet<string> entityNames,
+        Dictionary<string, RepositoryTeam> cdpTeamsByGithubSlug,
+        CancellationToken cancellationToken)
+    {
+        var githubTeamsByRepoName = new Dictionary<string, List<RepositoryTeam>>(StringComparer.OrdinalIgnoreCase);
+        var githubRepos = githubRepositoryNodes.ToList();
+        var repositoriesWithoutEntity = githubRepos
+            .Where(repo => !entityNames.Contains(repo.name))
+            .ToList();
+        var repositoriesWithEntity = githubRepos.Count - repositoriesWithoutEntity.Count;
+
+        _logger.LogInformation(
+            "Fetching GitHub teams for {RestTeamLookupCount} repos without an Entity ({EntityBackedCount} entity-backed)",
+            repositoriesWithoutEntity.Count,
+            repositoriesWithEntity);
+
+        foreach (var githubRepositoryNode in repositoriesWithoutEntity)
+        {
+            var teams = await GetTeamsForRepo(githubRepositoryNode.name, cdpTeamsByGithubSlug, cancellationToken);
+            githubTeamsByRepoName[githubRepositoryNode.name] = teams;
+        }
+
+        return githubTeamsByRepoName;
+    }
+
+    private async Task<Dictionary<string, RepositoryTeam>> GetRepositoryTeams(CancellationToken cancellationToken)
     {
         var cdpTeams = await teamsService.FindAll(cancellationToken);
 
-        return cdpTeams 
+        return cdpTeams
             .Where(t =>
             {
-                if (t.Github is not null)
-                {
-                    return true;
-                }
+                if (t.Github is not null) return true;
 
                 _logger.LogWarning("Skipping team with no GitHub slug: {@UserServiceTeam}", t);
                 return false;
             })
-            .Select(
-                t => new RepositoryTeam(t.Github!, t.TeamId, t.TeamName)
-            )
+            .GroupBy(t => t.Github!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group =>
+                {
+                    var team = group.First();
+                    return new RepositoryTeam(team.Github!, team.TeamId, team.TeamName);
+                },
+                StringComparer.OrdinalIgnoreCase
+            );
+    }
+
+    private async Task<List<RepositoryNode>> GetReposFromGithub(CancellationToken cancellationToken)
+    {
+        var githubRepositoryNodes = new List<RepositoryNode>();
+        string? repoCursor = null;
+        bool hasMoreRepos;
+
+        do
+        {
+            var page = await FetchSearchRepositoriesPage(repoCursor, cancellationToken);
+            if (page is null) break;
+
+            var repos = RemoveNullRepositoryNodes(page.Nodes);
+            githubRepositoryNodes.AddRange(repos);
+
+            _logger.LogInformation("Added {repos} repos, total {total}", repos.Count, githubRepositoryNodes.Count);
+
+            hasMoreRepos = page.HasNextPage;
+            repoCursor = page.EndCursor;
+        } while (hasMoreRepos);
+
+        return githubRepositoryNodes;
+    }
+
+    private async Task<SearchRepositoriesPage?> FetchSearchRepositoriesPage(
+        string? repoCursor,
+        CancellationToken cancellationToken)
+    {
+        var reposQuery = BuildSearchReposQuery($"org:{_githubOrgName} topic:cdp", repoCursor);
+        var jsonResponseRepos = await _client.PostAsync(_githubApiUrl, reposQuery, cancellationToken);
+        jsonResponseRepos.EnsureSuccessStatusCode();
+
+        var result = await jsonResponseRepos.Content.ReadFromJsonAsync<SearchRepoQueryResponse>(cancellationToken);
+        if (result is null)
+        {
+            var jsonString = await jsonResponseRepos.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError("The following was invalid json: {@JsonString}", jsonString);
+            throw new ApplicationException("response must be parsed correct");
+        }
+
+        if (result.data is null) return null;
+
+        return new SearchRepositoriesPage(
+            result.data.search.nodes,
+            result.data.search.pageInfo.hasNextPage,
+            result.data.search.pageInfo.endCursor
+        );
+    }
+
+    private sealed record SearchRepositoriesPage(
+        IEnumerable<RepositoryNode?> Nodes,
+        bool HasNextPage,
+        string? EndCursor
+    );
+
+    private async Task<List<RepositoryTeam>> GetTeamsForRepo(
+        string repoName,
+        Dictionary<string, RepositoryTeam> cdpTeamsByGithubSlug,
+        CancellationToken cancellationToken)
+    {
+        var teamsUrl = $"{_githubRestApiUrl}/repos/{_githubOrgName}/{repoName}/teams";
+        var response = await _client.GetAsync(teamsUrl, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var githubTeams = await response.Content.ReadFromJsonAsync<List<GithubTeamSummary>>(cancellationToken) ?? [];
+        return githubTeams
+            .Where(team => cdpTeamsByGithubSlug.ContainsKey(team.slug))
+            .Select(team => cdpTeamsByGithubSlug[team.slug])
+            .Distinct()
             .ToList();
     }
 
-    private async Task<Dictionary<RepositoryTeam, List<RepositoryNode>>> GetReposFromGithubByTeam(
-        List<RepositoryTeam> teams, CancellationToken cancellationToken)
-    {
-        var repositoriesByTeam = new Dictionary<RepositoryTeam, List<RepositoryNode>>();
-
-        foreach (var team in teams)
-        {
-            var teamSlug = team.Github;
-            if (string.IsNullOrEmpty(teamSlug)) continue;
-
-            _logger.LogInformation("Processing team: {TeamSlug}", teamSlug);
-
-            string? repoCursor = null;
-            var hasMoreRepos = true;
-            while (hasMoreRepos)
-            {
-                var reposQuery = BuildReposQuery(_githubOrgName, teamSlug, repoCursor);
-                var jsonResponseRepos = await _client.PostAsync(
-                    _githubApiUrl,
-                    reposQuery,
-                    cancellationToken
-                );
-                jsonResponseRepos.EnsureSuccessStatusCode();
-
-                var result = await jsonResponseRepos.Content.ReadFromJsonAsync<RepoQueryResponse>(cancellationToken);
-                if (result is null)
-                {
-                    var jsonString = await jsonResponseRepos.Content.ReadAsStringAsync(cancellationToken);
-                    _logger.LogError("The following was invalid json: {@JsonString}", jsonString);
-                    throw new ApplicationException("response must be parsed correct");
-                }
-
-                if (result.data == null)
-                {
-                    continue;
-                }
-
-                var repos = (result
-                    .data
-                    .organization
-                    .team
-                    ?.repositories.nodes ?? []
-                    ).ToList();
-
-                if (!repositoriesByTeam.TryAdd(team, repos))
-                {
-                    repositoriesByTeam[team].AddRange(repos);
-                }
-
-                _logger.LogInformation("Added {repos} repos, total {total}", repos.Count,
-                    repositoriesByTeam[team].Count);
-
-                hasMoreRepos = result.data.organization.team?.repositories.pageInfo.hasNextPage ?? false;
-                repoCursor = result.data.organization.team?.repositories.pageInfo.endCursor ?? null;
-            }
-        }
-
-        return repositoriesByTeam;
-    }
-
-    // To test queries, you can login to GitHub and try it here: https://docs.github.com/en/graphql/overview/explorer
-    private static StringContent BuildReposQuery(string githubOrgName, string teamSlug, string? repoCursor)
+    // To test queries, you can use gh api graphql -f query='query { viewer { login } }'. See: https://docs.github.com/en/graphql/guides/using-graphql-clients
+    private static StringContent BuildSearchReposQuery(string searchQuery, string? repoCursor)
     {
         var reposQuery = new
         {
             query = @"
-                        query ($githubOrgName: String!, $teamSlug: String!, $repoCursor: String) {
-                          organization(login: $githubOrgName) {
-                            team(slug: $teamSlug) {
-                              repositories(first: 100, after: $repoCursor) {
-                                pageInfo {
-                                  hasNextPage
-                                  endCursor
-                                }
-                                nodes {
-                                  name,
-                                  repositoryTopics(first: 30) {
-                                    nodes {
-                                      topic {
-                                        name
-                                      }
+                        query ($searchQuery: String!, $repoCursor: String) {
+                          search(query: $searchQuery, type: REPOSITORY, first: 100, after: $repoCursor) {
+                            pageInfo {
+                              hasNextPage
+                              endCursor
+                            }
+                            nodes {
+                              ... on Repository {
+                                name
+                                repositoryTopics(first: 30) {
+                                  nodes {
+                                    topic {
+                                      name
                                     }
-                                  },
-                                  description,
-                                  primaryLanguage {
-                                    name
-                                  },
-                                  url,
-                                  isArchived,
-                                  createdAt
+                                  }
                                 }
+                                description
+                                primaryLanguage {
+                                  name
+                                }
+                                url
+                                isArchived
+                                createdAt
                               }
                             }
                           }
                         }
                     ",
-            variables = new { githubOrgName, teamSlug, repoCursor }
+            variables = new { searchQuery, repoCursor }
         };
 
         return new StringContent(JsonSerializer.Serialize(reposQuery), Encoding.UTF8, "application/json");

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -59,7 +59,7 @@
         "Quartz": "Warning",
         "Defra.Cdp.Backend.Api.Mongo": "Information",
         "Defra.Cdp.Backend.Api.Mongo.MongoLock": "Warning",
-        "Defra.Cdp.Backend.Api.Services.Github": "Information",
+        "Defra.Cdp.Backend.Api.Services.Github": "Warning",
         "Defra.Cdp.Backend.Api": "Debug"
       }
     },

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -59,7 +59,7 @@
         "Quartz": "Warning",
         "Defra.Cdp.Backend.Api.Mongo": "Information",
         "Defra.Cdp.Backend.Api.Mongo.MongoLock": "Warning",
-        "Defra.Cdp.Backend.Api.Services.Github": "Warning",
+        "Defra.Cdp.Backend.Api.Services.Github": "Information",
         "Defra.Cdp.Backend.Api": "Debug"
       }
     },


### PR DESCRIPTION
- Replace per-team GraphQL repo sync with a single paginated search(org:… topic:cdp) query, so we stop depending on GitHub team membership to discover CDP repos.
- Treat Entity as the ownership source for services/test suites: if a repo name matches an Entity, store Teams = [] on the repository doc and skip GitHub team lookup.
- For repos without an Entity (templates/libraries/etc.), fetch teams via REST GET /repos/{org}/{repo}/teams and map GitHub slugs to CDP teams.