### PR TITLE
CORE-3799: Trigger the SNOW workflow on deployment successful

### DIFF
--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/DeploymentStateChangeEventHandlerTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/DeploymentStateChangeEventHandlerTests.cs
@@ -1,8 +1,11 @@
+using Defra.Cdp.Backend.Api.Config;
 using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Services.Aws.Deployments;
 using Defra.Cdp.Backend.Api.Services.Deployments;
 using Defra.Cdp.Backend.Api.Services.Notifications;
+using Defra.Cdp.Backend.Api.Services.Snow;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 
@@ -27,6 +30,7 @@ public class DeploymentStateChangeEventHandlerTests
     {
         var deploymentsService = Substitute.For<IDeploymentsService>();
         var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var snowDeploymentTriggerService = Substitute.For<ISnowDeploymentTriggerService>();
         var statusChange = StatusChange(
             oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_IN_PROGRESS,
             newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED);
@@ -35,7 +39,7 @@ public class DeploymentStateChangeEventHandlerTests
             .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_FAILED, "service deployment failed", Arg.Any<CancellationToken>())
             .Returns(statusChange);
 
-        var handler = Handler(deploymentsService, notificationDispatcher);
+        var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService);
 
         await handler.Handle("message-1", _deploymentFailedEvent, TestContext.Current.CancellationToken);
 
@@ -52,6 +56,9 @@ public class DeploymentStateChangeEventHandlerTests
                 e.Version == statusChange.Version &&
                 e.UserDisplayName == statusChange.UserDisplayName),
             Arg.Any<CancellationToken>());
+        await snowDeploymentTriggerService.DidNotReceive().TriggerDeploymentRecord(
+            Arg.Any<ServiceStatusChange>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -59,6 +66,7 @@ public class DeploymentStateChangeEventHandlerTests
     {
         var deploymentsService = Substitute.For<IDeploymentsService>();
         var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var snowDeploymentTriggerService = Substitute.For<ISnowDeploymentTriggerService>();
         var statusChange = StatusChange(
             oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_IN_PROGRESS,
             newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED);
@@ -76,7 +84,7 @@ public class DeploymentStateChangeEventHandlerTests
             .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED, "service deployment completed", Arg.Any<CancellationToken>())
             .Returns(statusChange);
 
-        var handler = Handler(deploymentsService, notificationDispatcher);
+        var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService);
 
         await handler.Handle("message-1", completedEvent, TestContext.Current.CancellationToken);
 
@@ -89,6 +97,9 @@ public class DeploymentStateChangeEventHandlerTests
                 e.PreviousVersion == statusChange.PreviousVersion &&
                 e.UserDisplayName == statusChange.UserDisplayName),
             Arg.Any<CancellationToken>());
+        await snowDeploymentTriggerService.DidNotReceive().TriggerDeploymentRecord(
+            Arg.Any<ServiceStatusChange>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -96,6 +107,7 @@ public class DeploymentStateChangeEventHandlerTests
     {
         var deploymentsService = Substitute.For<IDeploymentsService>();
         var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var snowDeploymentTriggerService = Substitute.For<ISnowDeploymentTriggerService>();
 
         deploymentsService
             .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_FAILED, "service deployment failed", Arg.Any<CancellationToken>())
@@ -103,12 +115,15 @@ public class DeploymentStateChangeEventHandlerTests
                 oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED,
                 newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_FAILED));
 
-        var handler = Handler(deploymentsService, notificationDispatcher);
+        var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService);
 
         await handler.Handle("message-1", _deploymentFailedEvent, TestContext.Current.CancellationToken);
 
         await notificationDispatcher.DidNotReceive().Dispatch(
             Arg.Any<INotificationEvent>(),
+            Arg.Any<CancellationToken>());
+        await snowDeploymentTriggerService.DidNotReceive().TriggerDeploymentRecord(
+            Arg.Any<ServiceStatusChange>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -117,36 +132,190 @@ public class DeploymentStateChangeEventHandlerTests
     {
         var deploymentsService = Substitute.For<IDeploymentsService>();
         var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var snowDeploymentTriggerService = Substitute.For<ISnowDeploymentTriggerService>();
 
         deploymentsService
             .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_FAILED, "service deployment failed", Arg.Any<CancellationToken>())
             .ReturnsNull();
 
-        var handler = Handler(deploymentsService, notificationDispatcher);
+        var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService);
 
         await handler.Handle("message-1", _deploymentFailedEvent, TestContext.Current.CancellationToken);
 
         await notificationDispatcher.DidNotReceive().Dispatch(
             Arg.Any<INotificationEvent>(),
             Arg.Any<CancellationToken>());
+        await snowDeploymentTriggerService.DidNotReceive().TriggerDeploymentRecord(
+            Arg.Any<ServiceStatusChange>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TriggersSnowWorkflowWhenProductionDeploymentCompletes()
+    {
+        var deploymentsService = Substitute.For<IDeploymentsService>();
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var snowDeploymentTriggerService = Substitute.For<ISnowDeploymentTriggerService>();
+        var statusChange = StatusChange(
+            oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_IN_PROGRESS,
+            newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+            environment: "prod");
+        var completedEvent = _deploymentFailedEvent with
+        {
+            Detail = _deploymentFailedEvent.Detail with
+            {
+                EventType = "INFO",
+                EventName = DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                Reason = "service deployment completed"
+            }
+        };
+
+        deploymentsService
+            .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                "service deployment completed", Arg.Any<CancellationToken>())
+            .Returns(statusChange);
+
+        var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService);
+
+        await handler.Handle("message-1", completedEvent, TestContext.Current.CancellationToken);
+
+        await snowDeploymentTriggerService.Received(1).TriggerDeploymentRecord(
+            Arg.Is<ServiceStatusChange>(change => change.Environment == "prod"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TriggersSnowWorkflowWhenAdditionalEnvironmentIsConfigured()
+    {
+        var deploymentsService = Substitute.For<IDeploymentsService>();
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var snowDeploymentTriggerService = Substitute.For<ISnowDeploymentTriggerService>();
+        var statusChange = StatusChange(
+            oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_IN_PROGRESS,
+            newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+            environment: "infra-dev");
+        var completedEvent = _deploymentFailedEvent with
+        {
+            Detail = _deploymentFailedEvent.Detail with
+            {
+                EventType = "INFO",
+                EventName = DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                Reason = "service deployment completed"
+            }
+        };
+
+        deploymentsService
+            .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                "service deployment completed", Arg.Any<CancellationToken>())
+            .Returns(statusChange);
+
+        // "infra-dev" is used to test the SNOW integration end-to-end without triggering it for every prod deployment.
+        var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService,
+            triggerEnvironments: ["prod", "infra-dev"]);
+
+        await handler.Handle("message-1", completedEvent, TestContext.Current.CancellationToken);
+
+        await snowDeploymentTriggerService.Received(1).TriggerDeploymentRecord(
+            Arg.Is<ServiceStatusChange>(change => change.Environment == "infra-dev"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotTriggerSnowWorkflowForEnvironmentNotInConfiguredList()
+    {
+        var deploymentsService = Substitute.For<IDeploymentsService>();
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var snowDeploymentTriggerService = Substitute.For<ISnowDeploymentTriggerService>();
+        var statusChange = StatusChange(
+            oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_IN_PROGRESS,
+            newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+            environment: "infra-dev");
+        var completedEvent = _deploymentFailedEvent with
+        {
+            Detail = _deploymentFailedEvent.Detail with
+            {
+                EventType = "INFO",
+                EventName = DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                Reason = "service deployment completed"
+            }
+        };
+
+        deploymentsService
+            .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                "service deployment completed", Arg.Any<CancellationToken>())
+            .Returns(statusChange);
+
+        var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService,
+            triggerEnvironments: ["prod"]);
+
+        await handler.Handle("message-1", completedEvent, TestContext.Current.CancellationToken);
+
+        await snowDeploymentTriggerService.DidNotReceive().TriggerDeploymentRecord(
+            Arg.Any<ServiceStatusChange>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SwallowsSnowTriggerExceptions()
+    {
+        var deploymentsService = Substitute.For<IDeploymentsService>();
+        var notificationDispatcher = Substitute.For<INotificationDispatcher>();
+        var snowDeploymentTriggerService = Substitute.For<ISnowDeploymentTriggerService>();
+        var statusChange = StatusChange(
+            oldStatus: DeploymentStatus.SERVICE_DEPLOYMENT_IN_PROGRESS,
+            newStatus: DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+            environment: "prod");
+        var completedEvent = _deploymentFailedEvent with
+        {
+            Detail = _deploymentFailedEvent.Detail with
+            {
+                EventType = "INFO",
+                EventName = DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                Reason = "service deployment completed"
+            }
+        };
+
+        deploymentsService
+            .UpdateDeploymentStatus("ecs-svc/123", DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED,
+                "service deployment completed", Arg.Any<CancellationToken>())
+            .Returns(statusChange);
+        snowDeploymentTriggerService
+            .When(service => service.TriggerDeploymentRecord(Arg.Any<ServiceStatusChange>(), Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("Boom"));
+
+        var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService);
+
+        var ex = await Record.ExceptionAsync(() =>
+            handler.Handle("message-1", completedEvent, TestContext.Current.CancellationToken));
+
+        Assert.Null(ex);
     }
 
     private static DeploymentStateChangeEventHandler Handler(
         IDeploymentsService deploymentsService,
-        INotificationDispatcher notificationDispatcher)
+        INotificationDispatcher notificationDispatcher,
+        ISnowDeploymentTriggerService snowDeploymentTriggerService,
+        string[]? triggerEnvironments = null)
     {
+        var snowOptions = Options.Create(new SnowOptions
+        {
+            TriggerEnvironments = triggerEnvironments ?? ["prod"]
+        });
+
         return new DeploymentStateChangeEventHandler(
             deploymentsService,
             notificationDispatcher,
+            snowDeploymentTriggerService,
+            snowOptions,
             NullLogger<DeploymentStateChangeEventHandler>.Instance);
     }
 
-    private static ServiceStatusChange StatusChange(string? oldStatus, string newStatus)
+    private static ServiceStatusChange StatusChange(string? oldStatus, string newStatus, string environment = "dev")
     {
         return new ServiceStatusChange
         {
             DeploymentId = "ecs-svc/123",
-            Environment = "dev",
+            Environment = environment,
             OldStatus = oldStatus,
             NewStatus = newStatus,
             EntityId = "cdp-portal-backend",

--- a/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/DeploymentStateChangeEventHandlerTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Aws/Deployments/DeploymentStateChangeEventHandlerTests.cs
@@ -209,7 +209,6 @@ public class DeploymentStateChangeEventHandlerTests
                 "service deployment completed", Arg.Any<CancellationToken>())
             .Returns(statusChange);
 
-        // "infra-dev" is used to test the SNOW integration end-to-end without triggering it for every prod deployment.
         var handler = Handler(deploymentsService, notificationDispatcher, snowDeploymentTriggerService,
             triggerEnvironments: ["prod", "infra-dev"]);
 

--- a/Defra.Cdp.Backend.Api.Tests/Services/Github/Workflows/TriggerWorkflowServiceTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Github/Workflows/TriggerWorkflowServiceTests.cs
@@ -27,6 +27,20 @@ public class TriggerWorkflowServiceTests
     }
 
     [Fact]
+    public async Task ReturnsNullWhenBodyIsAnEmptyStringRegardlessOfStatusCode()
+    {
+        var service = BuildService(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(string.Empty, Encoding.UTF8, "application/json")
+        });
+
+        var response = await service.TriggerWorkflow("cdp-deployments-snow", "deploy.yml",
+            new TestInputs("value"), TestContext.Current.CancellationToken);
+
+        Assert.Null(response);
+    }
+
+    [Fact]
     public async Task ReturnsDeserialisedResponseWhenBodyPresent()
     {
         var service = BuildService(_ => new HttpResponseMessage(HttpStatusCode.OK)

--- a/Defra.Cdp.Backend.Api.Tests/Services/Github/Workflows/TriggerWorkflowServiceTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Github/Workflows/TriggerWorkflowServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Serialization;
+using Defra.Cdp.Backend.Api.Services.Github.ScheduledTasks;
+using Defra.Cdp.Backend.Api.Services.Github.Workflows;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Github.Workflows;
+
+public class TriggerWorkflowServiceTests
+{
+    [Fact]
+    public async Task ReturnsNullWhenDispatchReturnsNoContentBody()
+    {
+        var service = BuildService(_ => new HttpResponseMessage(HttpStatusCode.NoContent)
+        {
+            Content = new StringContent(string.Empty, Encoding.UTF8, "application/json")
+        });
+
+        var response = await service.TriggerWorkflow("cdp-deployments-snow", "deploy.yml",
+            new TestInputs("value"), TestContext.Current.CancellationToken);
+
+        Assert.Null(response);
+    }
+
+    [Fact]
+    public async Task ReturnsDeserialisedResponseWhenBodyPresent()
+    {
+        var service = BuildService(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {
+                  "workflow_run_id": 99,
+                  "run_url": "https://api.github.com/repos/DEFRA/cdp-deployments-snow/actions/runs/99",
+                  "html_url": "https://github.com/DEFRA/cdp-deployments-snow/actions/runs/99"
+                }
+                """,
+                Encoding.UTF8,
+                "application/json")
+        });
+
+        var response = await service.TriggerWorkflow("cdp-deployments-snow", "deploy.yml",
+            new TestInputs("value"), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(response);
+        Assert.Equal(99, response.WorkflowRunId);
+    }
+
+    private static TriggerWorkflowService BuildService(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+    {
+        var handler = new StubMessageHandler(responseFactory);
+        var httpClient = new HttpClient(handler);
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient("GitHubClient").Returns(httpClient);
+
+        var credentials = Substitute.For<IGithubCredentialAndConnectionFactory>();
+        credentials.GetToken(Arg.Any<CancellationToken>()).Returns("token");
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Github:ApiUrl"] = "https://api.github.com",
+                ["Github:Organisation"] = "DEFRA"
+            })
+            .Build();
+
+        return new TriggerWorkflowService(httpClientFactory, credentials, config,
+            NullLogger<TriggerWorkflowService>.Instance);
+    }
+
+    private sealed class StubMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+
+    private sealed class TestInputs(string value) : IGithubWorkflowInputs
+    {
+        [JsonPropertyName("value")]
+        public string Value { get; init; } = value;
+    }
+}

--- a/Defra.Cdp.Backend.Api.Tests/Services/Snow/SnowDeploymentTriggerServiceTests.cs
+++ b/Defra.Cdp.Backend.Api.Tests/Services/Snow/SnowDeploymentTriggerServiceTests.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.Entities;
+using Defra.Cdp.Backend.Api.Services.Entities.Model;
+using Defra.Cdp.Backend.Api.Services.Github.Workflows;
+using Defra.Cdp.Backend.Api.Services.Snow;
+using Defra.Cdp.Backend.Api.Services.Snow.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using EntityStatus = Defra.Cdp.Backend.Api.Services.Entities.Model.Status;
+using EntityType = Defra.Cdp.Backend.Api.Services.Entities.Model.Type;
+
+namespace Defra.Cdp.Backend.Api.Tests.Services.Snow;
+
+public class SnowDeploymentTriggerServiceTests
+{
+    [Fact]
+    public async Task TriggersWorkflowWithStringifiedPayloads()
+    {
+        var triggerWorkflowService = Substitute.For<ITriggerWorkflowService>();
+        var entitiesService = Substitute.For<IEntitiesService>();
+
+        entitiesService.GetEntity("cdp-portal-backend", Arg.Any<CancellationToken>())
+            .Returns(new Entity
+            {
+                Name = "cdp-portal-backend",
+                Type = EntityType.Microservice,
+                Status = EntityStatus.Created,
+                Teams =
+                [
+                    new Team { TeamId = "zebra", Name = "Zebra Team" },
+                    new Team { TeamId = "alpha", Name = "Alpha Team" }
+                ]
+            });
+        triggerWorkflowService
+            .TriggerWorkflow(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<SnowDeploymentWorkflowInputs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GitHubTriggerWorkflowResponse { WorkflowRunId = 12345 });
+
+        var service = new SnowDeploymentTriggerService(triggerWorkflowService, entitiesService,
+            NullLogger<SnowDeploymentTriggerService>.Instance);
+        var statusChange = new ServiceStatusChange
+        {
+            DeploymentId = "deployment-123",
+            Environment = "prod",
+            OldStatus = "SERVICE_DEPLOYMENT_IN_PROGRESS",
+            NewStatus = "SERVICE_DEPLOYMENT_COMPLETED",
+            EntityId = "cdp-portal-backend",
+            Version = "1.2.3",
+            PreviousVersion = "1.2.2",
+            UserDisplayName = "Portal User"
+        };
+
+        await service.TriggerDeploymentRecord(statusChange, TestContext.Current.CancellationToken);
+
+        await triggerWorkflowService.Received(1).TriggerWorkflow(
+            "cdp-deployments-snow",
+            "deploy.yml",
+            Arg.Any<SnowDeploymentWorkflowInputs>(),
+            Arg.Any<CancellationToken>());
+
+        var call = triggerWorkflowService.ReceivedCalls().Single();
+        var inputs = Assert.IsType<SnowDeploymentWorkflowInputs>(call.GetArguments()[2]);
+        Assert.NotNull(inputs.ExtendedPayload);
+        var portalPayload = JsonSerializer.Deserialize<SnowPortalPayload>(inputs.PortalPayload);
+        var extendedPayload = JsonSerializer.Deserialize<SnowExtendedPayload>(inputs.ExtendedPayload!);
+
+        Assert.NotNull(portalPayload);
+        Assert.NotNull(extendedPayload);
+        Assert.Equal("cdp-portal-backend", portalPayload.Service);
+        Assert.Equal("deployment-123", portalPayload.CdpDeploymentId);
+        Assert.Equal("SERVICE_DEPLOYMENT_COMPLETED", portalPayload.LastDeploymentStatus);
+        Assert.NotNull(portalPayload.User);
+        Assert.Equal("Portal User", portalPayload.User.DisplayName);
+        Assert.Equal("Alpha Team", extendedPayload.TeamName);
+        Assert.Equal("1.2.2", extendedPayload.PreviousVersion);
+    }
+
+    [Fact]
+    public async Task UsesUnknownTeamNameWhenServiceHasNoTeams()
+    {
+        var triggerWorkflowService = Substitute.For<ITriggerWorkflowService>();
+        var entitiesService = Substitute.For<IEntitiesService>();
+
+        entitiesService.GetEntity("cdp-portal-backend", Arg.Any<CancellationToken>())
+            .Returns(new Entity
+            {
+                Name = "cdp-portal-backend",
+                Type = EntityType.Microservice,
+                Status = EntityStatus.Created
+            });
+        triggerWorkflowService
+            .TriggerWorkflow(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<SnowDeploymentWorkflowInputs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GitHubTriggerWorkflowResponse());
+
+        var service = new SnowDeploymentTriggerService(triggerWorkflowService, entitiesService,
+            NullLogger<SnowDeploymentTriggerService>.Instance);
+        var statusChange = new ServiceStatusChange
+        {
+            DeploymentId = "deployment-123",
+            Environment = "prod",
+            OldStatus = "SERVICE_DEPLOYMENT_IN_PROGRESS",
+            NewStatus = "SERVICE_DEPLOYMENT_COMPLETED",
+            EntityId = "cdp-portal-backend",
+            Version = "1.2.3",
+            PreviousVersion = null,
+            UserDisplayName = null
+        };
+
+        await service.TriggerDeploymentRecord(statusChange, TestContext.Current.CancellationToken);
+
+        var call = triggerWorkflowService.ReceivedCalls().Single();
+        var inputs = Assert.IsType<SnowDeploymentWorkflowInputs>(call.GetArguments()[2]);
+        Assert.NotNull(inputs.ExtendedPayload);
+        var extendedPayload = JsonSerializer.Deserialize<SnowExtendedPayload>(inputs.ExtendedPayload!);
+        var portalPayload = JsonSerializer.Deserialize<SnowPortalPayload>(inputs.PortalPayload);
+
+        Assert.NotNull(extendedPayload);
+        Assert.NotNull(portalPayload);
+        Assert.Equal(SnowPayloadDefaults.Unknown, extendedPayload.TeamName);
+        Assert.Null(portalPayload.User);
+    }
+}

--- a/Defra.Cdp.Backend.Api/Config/SnowOptions.cs
+++ b/Defra.Cdp.Backend.Api/Config/SnowOptions.cs
@@ -1,0 +1,24 @@
+namespace Defra.Cdp.Backend.Api.Config;
+
+/// <summary>
+/// Controls which CDP environments trigger the ServiceNow deployment record workflow.
+/// </summary>
+/// <remarks>
+/// <para>
+/// cdp-portal-backend runs as a single shared instance that processes deployment events for every
+/// CDP environment (see EnvironmentMappings), so this can't be set per-environment via ASPNETCORE_ENVIRONMENT
+/// appsettings files alone for anything other than local runs. The real default (["prod"]) lives in
+/// appsettings.json; override Snow__TriggerEnvironments (e.g. via a CDP_ prefixed environment variable) to
+/// temporarily include another environment such as infra-dev for end-to-end testing.
+/// </para>
+/// <para>
+/// TriggerEnvironments must default to an empty array here, not e.g. ["prod"]. The configuration binder
+/// appends bound values onto an existing non-empty array/list default instead of replacing it, so a
+/// non-empty default here would silently duplicate entries already set in appsettings.json.
+/// </para>
+/// </remarks>
+public class SnowOptions
+{
+    public const string Prefix = "Snow";
+    public string[] TriggerEnvironments { get; set; } = [];
+}

--- a/Defra.Cdp.Backend.Api/Config/SnowOptions.cs
+++ b/Defra.Cdp.Backend.Api/Config/SnowOptions.cs
@@ -4,18 +4,11 @@ namespace Defra.Cdp.Backend.Api.Config;
 /// Controls which CDP environments trigger the ServiceNow deployment record workflow.
 /// </summary>
 /// <remarks>
-/// <para>
-/// cdp-portal-backend runs as a single shared instance that processes deployment events for every
-/// CDP environment (see EnvironmentMappings), so this can't be set per-environment via ASPNETCORE_ENVIRONMENT
-/// appsettings files alone for anything other than local runs. The real default (["prod"]) lives in
-/// appsettings.json; override Snow__TriggerEnvironments (e.g. via a CDP_ prefixed environment variable) to
-/// temporarily include another environment such as infra-dev for end-to-end testing.
-/// </para>
-/// <para>
-/// TriggerEnvironments must default to an empty array here, not e.g. ["prod"]. The configuration binder
-/// appends bound values onto an existing non-empty array/list default instead of replacing it, so a
-/// non-empty default here would silently duplicate entries already set in appsettings.json.
-/// </para>
+/// Defaults to empty (opt-in only, via config) because cdp-portal-backend is a single shared instance
+/// handling deployment events for every CDP environment, not one instance per environment.
+///
+/// Must default to an empty array, not e.g. ["prod"]: the configuration binder appends bound values onto a
+/// non-empty default instead of replacing it, silently duplicating entries already set in config.
 /// </remarks>
 public class SnowOptions
 {

--- a/Defra.Cdp.Backend.Api/Config/SnowOptions.cs
+++ b/Defra.Cdp.Backend.Api/Config/SnowOptions.cs
@@ -1,15 +1,5 @@
 namespace Defra.Cdp.Backend.Api.Config;
 
-/// <summary>
-/// Controls which CDP environments trigger the ServiceNow deployment record workflow.
-/// </summary>
-/// <remarks>
-/// Defaults to empty (opt-in only, via config) because cdp-portal-backend is a single shared instance
-/// handling deployment events for every CDP environment, not one instance per environment.
-///
-/// Must default to an empty array, not e.g. ["prod"]: the configuration binder appends bound values onto a
-/// non-empty default instead of replacing it, silently duplicating entries already set in config.
-/// </remarks>
 public class SnowOptions
 {
     public const string Prefix = "Snow";

--- a/Defra.Cdp.Backend.Api/Program.cs
+++ b/Defra.Cdp.Backend.Api/Program.cs
@@ -34,6 +34,7 @@ using Defra.Cdp.Backend.Api.Services.Scheduler.Model;
 using Defra.Cdp.Backend.Api.Services.Scheduler.TestSuiteDeployment;
 using Defra.Cdp.Backend.Api.Services.Secrets;
 using Defra.Cdp.Backend.Api.Services.Shuttering;
+using Defra.Cdp.Backend.Api.Services.Snow;
 using Defra.Cdp.Backend.Api.Services.Teams;
 using Defra.Cdp.Backend.Api.Services.TenantArtifacts;
 using Defra.Cdp.Backend.Api.Services.Terminal;
@@ -156,6 +157,7 @@ builder.Services.Configure<PlatformEventListenerOptions>(
 builder.Services.Configure<DeployablesClientOptions>(builder.Configuration.GetSection(DeployablesClientOptions.Prefix));
 builder.Services.Configure<CloudWatchMetricsOptions>(builder.Configuration.GetSection(CloudWatchMetricsOptions.Prefix));
 builder.Services.Configure<TestRunnerOptions>(builder.Configuration.GetSection(TestRunnerOptions.Prefix));
+builder.Services.Configure<SnowOptions>(builder.Configuration.GetSection(SnowOptions.Prefix));
 
 // AWS Clients
 builder.Services.AddAwsClients(builder.Configuration, builder.IsDevMode());
@@ -194,6 +196,7 @@ builder.Services.AddSingleton<ITriggerWorkflowService, TriggerWorkflowService>()
 builder.Services.AddSingleton<IResourceRequestService, ResourceRequestService>();
 builder.Services.AddSingleton<ICreateResourceValidator, CreateResourceValidator>();
 builder.Services.AddSingleton<IEntityResourceService, EntityResourceService>();
+builder.Services.AddSingleton<ISnowDeploymentTriggerService, SnowDeploymentTriggerService>();
 
 // Grafana alert promotion
 builder.Services.AddSingleton<IGrafanaPlaygroundService, GrafanaPlaygroundService>();

--- a/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
+++ b/Defra.Cdp.Backend.Api/Services/Aws/Deployments/DeploymentStateChangeHandler.cs
@@ -1,12 +1,17 @@
+using Defra.Cdp.Backend.Api.Config;
 using Defra.Cdp.Backend.Api.Models;
 using Defra.Cdp.Backend.Api.Services.Deployments;
 using Defra.Cdp.Backend.Api.Services.Notifications;
+using Defra.Cdp.Backend.Api.Services.Snow;
+using Microsoft.Extensions.Options;
 
 namespace Defra.Cdp.Backend.Api.Services.Aws.Deployments;
 
 public class DeploymentStateChangeEventHandler(
     IDeploymentsService deploymentsService,
     INotificationDispatcher notificationDispatcher,
+    ISnowDeploymentTriggerService snowDeploymentTriggerService,
+    IOptions<SnowOptions> snowOptions,
     ILogger<DeploymentStateChangeEventHandler> logger)
 {
     public async Task Handle(string id, EcsDeploymentStateChangeEvent ecsEvent, CancellationToken cancellationToken)
@@ -14,6 +19,7 @@ public class DeploymentStateChangeEventHandler(
         logger.LogInformation("{Id} Handling EcsDeploymentStateChange Update {DeploymentId}, {Name} {Reason}", id, ecsEvent.Detail.DeploymentId, ecsEvent.Detail.EventName, ecsEvent.Detail.Reason);
         var statusChange = await deploymentsService.UpdateDeploymentStatus(ecsEvent.Detail.DeploymentId, ecsEvent.Detail.EventName, ecsEvent.Detail.Reason, cancellationToken);
         await TriggerDeploymentNotificationOnTransition(statusChange, cancellationToken);
+        await TriggerSnowWorkflowOnTransition(statusChange, cancellationToken);
     }
 
     private async Task TriggerDeploymentNotificationOnTransition(ServiceStatusChange? statusChange, CancellationToken cancellationToken)
@@ -45,5 +51,30 @@ public class DeploymentStateChangeEventHandler(
 
         if (notificationEvent != null)
             await notificationDispatcher.Dispatch(notificationEvent, cancellationToken);
+    }
+
+    private async Task TriggerSnowWorkflowOnTransition(ServiceStatusChange? statusChange,
+        CancellationToken cancellationToken)
+    {
+        if (statusChange is null || statusChange.NewStatus == statusChange.OldStatus)
+            return;
+
+        if (statusChange.NewStatus != DeploymentStatus.SERVICE_DEPLOYMENT_COMPLETED ||
+            !snowOptions.Value.TriggerEnvironments.Contains(statusChange.Environment,
+                StringComparer.OrdinalIgnoreCase))
+            return;
+
+        try
+        {
+            await snowDeploymentTriggerService.TriggerDeploymentRecord(statusChange, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to trigger SNOW workflow for deployment {DeploymentId} {Service} in {Environment}",
+                statusChange.DeploymentId,
+                statusChange.EntityId,
+                statusChange.Environment);
+        }
     }
 }

--- a/Defra.Cdp.Backend.Api/Services/Github/Workflows/TriggerWorkflowService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Github/Workflows/TriggerWorkflowService.cs
@@ -45,7 +45,13 @@ public class TriggerWorkflowService(
         logger.LogInformation("Trigger GitHub {Workflow} responded with {Status}", workflow, response.StatusCode);
 
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<GitHubTriggerWorkflowResponse>(
-            cancellationToken: cancellationToken);
+        var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(responseContent))
+        {
+            logger.LogInformation("Trigger GitHub {Workflow} returned an empty response body", workflow);
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<GitHubTriggerWorkflowResponse>(responseContent);
     }
 }

--- a/Defra.Cdp.Backend.Api/Services/Snow/ISnowDeploymentTriggerService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Snow/ISnowDeploymentTriggerService.cs
@@ -25,7 +25,7 @@ public class SnowDeploymentTriggerService(
     {
         var entity = await entitiesService.GetEntity(statusChange.EntityId, cancellationToken);
 
-        // TODO: verify this is the right team to report to ServiceNow when a service has multiple owning teams.
+        // Decided: for services with multiple owning teams, just report the first one (by team ID) to ServiceNow.
         var teamName = entity?.Teams
             .OrderBy(team => team.TeamId, StringComparer.OrdinalIgnoreCase)
             .Select(team => string.IsNullOrWhiteSpace(team.Name) ? team.TeamId : team.Name)

--- a/Defra.Cdp.Backend.Api/Services/Snow/ISnowDeploymentTriggerService.cs
+++ b/Defra.Cdp.Backend.Api/Services/Snow/ISnowDeploymentTriggerService.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using Defra.Cdp.Backend.Api.Services.Deployments;
+using Defra.Cdp.Backend.Api.Services.Entities;
+using Defra.Cdp.Backend.Api.Services.Github.Workflows;
+using Defra.Cdp.Backend.Api.Services.Snow.Models;
+using Serilog.Context;
+
+namespace Defra.Cdp.Backend.Api.Services.Snow;
+
+public interface ISnowDeploymentTriggerService
+{
+    Task TriggerDeploymentRecord(ServiceStatusChange statusChange, CancellationToken cancellationToken);
+}
+
+public class SnowDeploymentTriggerService(
+    ITriggerWorkflowService triggerWorkflowService,
+    IEntitiesService entitiesService,
+    ILogger<SnowDeploymentTriggerService> logger) : ISnowDeploymentTriggerService
+{
+    private const string Repo = "cdp-deployments-snow";
+    private const string Workflow = "deploy.yml";
+    private const string SnowWorkflowTriggerEventAction = "snow-deployment-record-triggered";
+
+    public async Task TriggerDeploymentRecord(ServiceStatusChange statusChange, CancellationToken cancellationToken)
+    {
+        var entity = await entitiesService.GetEntity(statusChange.EntityId, cancellationToken);
+
+        // TODO: verify this is the right team to report to ServiceNow when a service has multiple owning teams.
+        var teamName = entity?.Teams
+            .OrderBy(team => team.TeamId, StringComparer.OrdinalIgnoreCase)
+            .Select(team => string.IsNullOrWhiteSpace(team.Name) ? team.TeamId : team.Name)
+            .FirstOrDefault()
+            ?? SnowPayloadDefaults.Unknown;
+
+        var portalPayload = new SnowPortalPayload
+        {
+            Service = statusChange.EntityId,
+            Version = statusChange.Version,
+            Environment = statusChange.Environment,
+            LastDeploymentStatus = statusChange.NewStatus,
+            CdpDeploymentId = statusChange.DeploymentId,
+            Updated = DateTime.UtcNow,
+            User = string.IsNullOrWhiteSpace(statusChange.UserDisplayName)
+                ? null
+                : new SnowPortalUserPayload { DisplayName = statusChange.UserDisplayName }
+        };
+
+        var extendedPayload = new SnowExtendedPayload
+        {
+            TeamName = teamName,
+            PreviousVersion = statusChange.PreviousVersion
+        };
+
+        var inputs = new SnowDeploymentWorkflowInputs(
+            JsonSerializer.Serialize(portalPayload),
+            JsonSerializer.Serialize(extendedPayload)
+        );
+
+        using (LogContext.PushProperty("event.action", SnowWorkflowTriggerEventAction))
+        {
+            logger.LogInformation(
+                "Triggering SNOW deployment record for {Service} {Version} in {Environment}, deployment {DeploymentId}, team {TeamName}",
+                statusChange.EntityId,
+                statusChange.Version,
+                statusChange.Environment,
+                statusChange.DeploymentId,
+                teamName);
+
+            var response =
+                await triggerWorkflowService.TriggerWorkflow(Repo, Workflow, inputs, cancellationToken);
+
+            logger.LogInformation(
+                "Triggered SNOW workflow for deployment {DeploymentId}: response body present {HasWorkflowResponse}, run id {WorkflowRunId}, run url {WorkflowRunUrl}",
+                statusChange.DeploymentId,
+                response != null,
+                response?.WorkflowRunId,
+                response?.WorkflowRunUrl);
+        }
+    }
+}

--- a/Defra.Cdp.Backend.Api/Services/Snow/Models/SnowDeploymentWorkflowInputs.cs
+++ b/Defra.Cdp.Backend.Api/Services/Snow/Models/SnowDeploymentWorkflowInputs.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+using Defra.Cdp.Backend.Api.Services.Github.Workflows;
+
+namespace Defra.Cdp.Backend.Api.Services.Snow.Models;
+
+/// <summary>
+/// Inputs for the "ServiceNow Deployment Record" workflow_dispatch in cdp-deployments-snow.
+/// </summary>
+/// <remarks>
+/// portal_payload and extended_payload are stringified JSON, not nested objects, because
+/// GitHub Actions workflow_dispatch only accepts flat string/boolean/choice inputs - it does not
+/// support nested JSON. Packing the whole deployment record into one string input also avoids
+/// needing to add a new workflow input (and a matching change in cdp-deployments-snow) every time
+/// a new field is needed; cdp-deployments-snow parses these two strings back into structured
+/// payloads itself (see PAYLOAD.md). Same pattern as GenericCdpWorkflowInputs.Commands.
+/// </remarks>
+public class SnowDeploymentWorkflowInputs(string portalPayload, string? extendedPayload) : IGithubWorkflowInputs
+{
+    [JsonPropertyName("portal_payload")]
+    public string PortalPayload { get; init; } = portalPayload;
+
+    [JsonPropertyName("extended_payload")]
+    public string? ExtendedPayload { get; init; } = extendedPayload;
+}

--- a/Defra.Cdp.Backend.Api/Services/Snow/Models/SnowPayloads.cs
+++ b/Defra.Cdp.Backend.Api/Services/Snow/Models/SnowPayloads.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.Cdp.Backend.Api.Services.Snow.Models;
+
+public static class SnowPayloadDefaults
+{
+    public const string Unknown = "UNKNOWN";
+}
+
+public class SnowPortalPayload
+{
+    [JsonPropertyName("service")]
+    public required string Service { get; init; }
+
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+
+    [JsonPropertyName("environment")]
+    public required string Environment { get; init; }
+
+    [JsonPropertyName("user")]
+    public SnowPortalUserPayload? User { get; init; }
+
+    [JsonPropertyName("cdpDeploymentId")]
+    public required string CdpDeploymentId { get; init; }
+
+    [JsonPropertyName("lastDeploymentStatus")]
+    public required string LastDeploymentStatus { get; init; }
+
+    [JsonPropertyName("updated")]
+    public required DateTime Updated { get; init; }
+}
+
+public class SnowPortalUserPayload
+{
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+}
+
+public class SnowExtendedPayload
+{
+    [JsonPropertyName("team_name")]
+    public required string TeamName { get; init; }
+
+    [JsonPropertyName("previous_version")]
+    public string? PreviousVersion { get; init; }
+
+    // TODO: assignment_group is not set, so every team's deployments currently land in
+    // cdp-deployments-snow's single default ServiceNow group. Clarify whether teams need their
+    // own assignment group, and if so, where that sys_id should be sourced from.
+}

--- a/Defra.Cdp.Backend.Api/Services/Snow/Models/SnowPayloads.cs
+++ b/Defra.Cdp.Backend.Api/Services/Snow/Models/SnowPayloads.cs
@@ -45,7 +45,6 @@ public class SnowExtendedPayload
     [JsonPropertyName("previous_version")]
     public string? PreviousVersion { get; init; }
 
-    // TODO: assignment_group is not set, so every team's deployments currently land in
-    // cdp-deployments-snow's single default ServiceNow group. Clarify whether teams need their
-    // own assignment group, and if so, where that sys_id should be sourced from.
+    // assignment_group is intentionally not set: cdp-deployments-snow's default ServiceNow group covers
+    // every team for now, and that isn't expected to change.
 }

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -30,6 +30,9 @@
   "TestRunner": {
     "SnapshotDashboardEnabled": false
   },
+  "Snow": {
+    "TriggerEnvironments": [ "prod", "infra-dev" ]
+  },
   "MigrationsBucket": "cdp-migrations",
   "SelfServiceOpsSecret": "9fb76f1abc39a08f3147fcdb5cb7ad9cb8dc3609af47c0553b81ac116109e070",
   "DetailedErrors": true,

--- a/Defra.Cdp.Backend.Api/appsettings.Development.json
+++ b/Defra.Cdp.Backend.Api/appsettings.Development.json
@@ -31,7 +31,7 @@
     "SnapshotDashboardEnabled": false
   },
   "Snow": {
-    "TriggerEnvironments": [ "prod", "infra-dev" ]
+    "TriggerEnvironments": [ "infra-dev" ]
   },
   "MigrationsBucket": "cdp-migrations",
   "SelfServiceOpsSecret": "9fb76f1abc39a08f3147fcdb5cb7ad9cb8dc3609af47c0553b81ac116109e070",

--- a/Defra.Cdp.Backend.Api/appsettings.json
+++ b/Defra.Cdp.Backend.Api/appsettings.json
@@ -55,6 +55,9 @@
     "SnapshotDashboard": "CDP Platform Test Impact",
     "SnapshotDashboardEnabled": true
   },
+  "Snow": {
+    "TriggerEnvironments": []
+  },
   "EcsEvents": {
     "QueueUrl": "http://localhost:4566/000000000000/ecs-deployments",
     "Enabled": true


### PR DESCRIPTION
Trigger the ServiceNow deployment record workflow when a production deployment completes successfully.

- add SnowDeploymentTriggerService to build the PORTAL_PAYLOAD/EXTENDED_PAYLOAD JSON
- trigger cdp-deployments-snow via the existing GitHub workflow_dispatch helper
- fix TriggerWorkflowService to handle GitHub's 204/empty-body workflow_dispatch response instead of throwing
- add structured logging (event.action=snow-deployment-record-triggered) for the SNOW OpenSearch dashboard

Decisions:
- What to pass if the service has more than one team? **The first one by id**
- What to set in `assignment_group` / `sys_id`: https://github.com/DEFRA/cdp-deployments-snow/blob/main/PAYLOAD.md: **can be skipped, the SNOW repo handles it**
